### PR TITLE
Prevent multiple table names in Exporter

### DIFF
--- a/tests/data_connection/test_DataConnection.py
+++ b/tests/data_connection/test_DataConnection.py
@@ -357,7 +357,9 @@ class TestDataConnection(unittest.TestCase):
         self.assertEqual(model.rowCount(), 1)
         index = model.index(0, 0)
         self.assertEqual(index.data(), "data.csv")
-        self.assertEqual(index.data(Qt.ItemDataRole.UserRole + 1), os.path.join(self.project.items_dir, "dc", "data.csv"))
+        self.assertEqual(
+            index.data(Qt.ItemDataRole.UserRole + 1), os.path.join(self.project.items_dir, "dc", "data.csv")
+        )
 
     def test_deleting_data_file_removes_it_from_dc(self):
         file_a = Path(self.data_connection.data_dir) / "data.dat"

--- a/tests/exporter/mvcmodels/test_mapping_editor_table_model.py
+++ b/tests/exporter/mvcmodels/test_mapping_editor_table_model.py
@@ -58,6 +58,19 @@ class TestMappingTableModel(unittest.TestCase):
         self.assertTrue(model.setData(model.index(0, 1), "23"))
         self.assertEqual(model.index(0, 1).data(), "23")
 
+    def test_setData_prevents_duplicate_table_name_positions(self):
+        model = MappingEditorTableModel("mapping", object_export(Position.table_name, 0), self._undo_stack, MagicMock())
+        self.assertEqual(model.rowCount(), 2)
+        self.assertEqual(model.index(0, 0).data(), "Object classes")
+        self.assertEqual(model.index(0, 1).data(), "table name")
+        self.assertEqual(model.index(1, 0).data(), "Objects")
+        self.assertEqual(model.index(1, 1).data(), "1")
+        model.setData(model.index(1, 1), "table name")
+        self.assertEqual(model.index(0, 0).data(), "Object classes")
+        self.assertEqual(model.index(0, 1).data(), "1")
+        self.assertEqual(model.index(1, 0).data(), "Objects")
+        self.assertEqual(model.index(1, 1).data(), "table name")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/exporter/widgets/__init__.py
+++ b/tests/exporter/widgets/__init__.py
@@ -1,0 +1,10 @@
+######################################################################################################################
+# Copyright (C) 2017-2023 Spine project consortium
+# This file is part of Spine Items.
+# Spine Items is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################

--- a/tests/exporter/widgets/test_specification_editor_window.py
+++ b/tests/exporter/widgets/test_specification_editor_window.py
@@ -1,0 +1,56 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Items.
+# Spine Items is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+"""Unit tests for the ``specification_editor_window`` module."""
+from tempfile import TemporaryDirectory
+import unittest
+
+from PySide6.QtWidgets import QApplication
+
+from spine_items.exporter.widgets.specification_editor_window import SpecificationEditorWindow
+from ...mock_helpers import clean_up_toolbox, create_toolboxui_with_project
+
+
+class TestSpecificationEditorWindow(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not QApplication.instance():
+            QApplication()
+
+    def setUp(self):
+        self._temp_dir = TemporaryDirectory()
+        self._toolbox = create_toolboxui_with_project(self._temp_dir.name)
+
+    def tearDown(self):
+        clean_up_toolbox(self._toolbox)
+        self._temp_dir.cleanup()
+
+    def test_empty_editor(self):
+        editor = SpecificationEditorWindow(self._toolbox)
+        self.assertEqual(editor._ui.mappings_table.model().rowCount(), 1)
+        self.assertEqual(editor._ui.mappings_table.model().index(0, 0).data(), "Mapping 1")
+
+    def test_mapping_in_table_name_position_disables_fixed_table_name_widgets(self):
+        editor = SpecificationEditorWindow(self._toolbox)
+        self.assertTrue(editor._ui.fix_table_name_check_box.isEnabled())
+        self.assertFalse(editor._ui.fix_table_name_check_box.isChecked())
+        self.assertFalse(editor._ui.fix_table_name_line_edit.isEnabled())
+        self.assertEqual(editor._ui.fix_table_name_line_edit.text(), "")
+        editor._ui.mappings_table.setCurrentIndex(editor._ui.mappings_table.model().index(0, 0))
+        model = editor._ui.mapping_table_view.model()
+        model.setData(model.index(0, 1), "table name")
+        self.assertFalse(editor._ui.fix_table_name_check_box.isEnabled())
+        self.assertFalse(editor._ui.fix_table_name_check_box.isChecked())
+        self.assertFalse(editor._ui.fix_table_name_line_edit.isEnabled())
+        self.assertEqual(editor._ui.fix_table_name_line_edit.text(), "")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/importer/mvcmodels/test_SourceDataTableModel.py
+++ b/tests/importer/mvcmodels/test_SourceDataTableModel.py
@@ -107,21 +107,31 @@ class TestSourceDataTableModel(unittest.TestCase):
         list_index = self._add_mapping(mappings_model, {"map_type": "ObjectClass", "name": 0})
         self._model.set_mapping_list_index(list_index)
         entity_class_color = self._find_color(list_index, "Object class names")
-        self.assertEqual(self._model.data(self._model.index(0, 0), role=Qt.ItemDataRole.BackgroundRole), entity_class_color)
-        self.assertEqual(self._model.data(self._model.index(1, 0), role=Qt.ItemDataRole.BackgroundRole), entity_class_color)
+        self.assertEqual(
+            self._model.data(self._model.index(0, 0), role=Qt.ItemDataRole.BackgroundRole), entity_class_color
+        )
+        self.assertEqual(
+            self._model.data(self._model.index(1, 0), role=Qt.ItemDataRole.BackgroundRole), entity_class_color
+        )
         # row not showing color if the start reading row is specified
         list_index = self._add_mapping(mappings_model, {"map_type": "ObjectClass", "name": 0, "read_start_row": 1})
         self._model.set_mapping_list_index(list_index)
         entity_class_color = self._find_color(list_index, "Object class names")
         self.assertEqual(self._model.data(self._model.index(0, 0), role=Qt.ItemDataRole.BackgroundRole), None)
-        self.assertEqual(self._model.data(self._model.index(1, 0), role=Qt.ItemDataRole.BackgroundRole), entity_class_color)
+        self.assertEqual(
+            self._model.data(self._model.index(1, 0), role=Qt.ItemDataRole.BackgroundRole), entity_class_color
+        )
         # row not showing color if the row is pivoted
         list_index = self._add_mapping(
             mappings_model, {"map_type": "ObjectClass", "name": 0, "object": {"map_type": "row", "value_reference": 0}}
         )
         self._model.set_mapping_list_index(list_index)
-        self.assertNotEqual(self._model.data(self._model.index(0, 0), role=Qt.ItemDataRole.BackgroundRole), entity_class_color)
-        self.assertEqual(self._model.data(self._model.index(1, 0), role=Qt.ItemDataRole.BackgroundRole), entity_class_color)
+        self.assertNotEqual(
+            self._model.data(self._model.index(0, 0), role=Qt.ItemDataRole.BackgroundRole), entity_class_color
+        )
+        self.assertEqual(
+            self._model.data(self._model.index(1, 0), role=Qt.ItemDataRole.BackgroundRole), entity_class_color
+        )
         mappings_model.deleteLater()
 
     def test_mapping_pivoted_colors(self):
@@ -165,7 +175,9 @@ class TestSourceDataTableModel(unittest.TestCase):
         metadata_color = self._find_color(list_index, "Object metadata")
         self.assertEqual(self._model.data(self._model.index(0, 0), role=Qt.ItemDataRole.BackgroundRole), None)
         self.assertEqual(self._model.data(self._model.index(0, 1), role=Qt.ItemDataRole.BackgroundRole), entity_color)
-        self.assertEqual(self._model.data(self._model.index(1, 0), role=Qt.ItemDataRole.BackgroundRole), entity_class_color)
+        self.assertEqual(
+            self._model.data(self._model.index(1, 0), role=Qt.ItemDataRole.BackgroundRole), entity_class_color
+        )
         self.assertEqual(self._model.data(self._model.index(1, 1), role=Qt.ItemDataRole.BackgroundRole), metadata_color)
         mappings_model.deleteLater()
 
@@ -199,8 +211,12 @@ class TestSourceDataTableModel(unittest.TestCase):
         self.assertEqual(self._model.data(self._model.index(0, 0), role=Qt.ItemDataRole.BackgroundRole), None)
         self.assertEqual(self._model.data(self._model.index(0, 1), role=Qt.ItemDataRole.BackgroundRole), None)
         self.assertEqual(self._model.data(self._model.index(0, 2), role=Qt.ItemDataRole.BackgroundRole), None)
-        self.assertEqual(self._model.data(self._model.index(0, 3), role=Qt.ItemDataRole.BackgroundRole), parameter_definition_color)
-        self.assertEqual(self._model.data(self._model.index(1, 0), role=Qt.ItemDataRole.BackgroundRole), alternative_color)
+        self.assertEqual(
+            self._model.data(self._model.index(0, 3), role=Qt.ItemDataRole.BackgroundRole), parameter_definition_color
+        )
+        self.assertEqual(
+            self._model.data(self._model.index(1, 0), role=Qt.ItemDataRole.BackgroundRole), alternative_color
+        )
         self.assertEqual(self._model.data(self._model.index(1, 1), role=Qt.ItemDataRole.BackgroundRole), entity_color)
         self.assertEqual(self._model.data(self._model.index(1, 2), role=Qt.ItemDataRole.BackgroundRole), index_color)
         self.assertEqual(self._model.data(self._model.index(1, 3), role=Qt.ItemDataRole.BackgroundRole), value_color)
@@ -236,8 +252,12 @@ class TestSourceDataTableModel(unittest.TestCase):
         self.assertEqual(self._model.data(self._model.index(0, 0), role=Qt.ItemDataRole.BackgroundRole), None)
         self.assertEqual(self._model.data(self._model.index(0, 1), role=Qt.ItemDataRole.BackgroundRole), None)
         self.assertEqual(self._model.data(self._model.index(0, 2), role=Qt.ItemDataRole.BackgroundRole), None)
-        self.assertEqual(self._model.data(self._model.index(0, 3), role=Qt.ItemDataRole.BackgroundRole), parameter_definition_color)
-        self.assertEqual(self._model.data(self._model.index(1, 0), role=Qt.ItemDataRole.BackgroundRole), alternative_color)
+        self.assertEqual(
+            self._model.data(self._model.index(0, 3), role=Qt.ItemDataRole.BackgroundRole), parameter_definition_color
+        )
+        self.assertEqual(
+            self._model.data(self._model.index(1, 0), role=Qt.ItemDataRole.BackgroundRole), alternative_color
+        )
         self.assertEqual(self._model.data(self._model.index(1, 1), role=Qt.ItemDataRole.BackgroundRole), entity_color)
         self.assertEqual(self._model.data(self._model.index(1, 2), role=Qt.ItemDataRole.BackgroundRole), index_color)
         self.assertEqual(self._model.data(self._model.index(1, 3), role=Qt.ItemDataRole.BackgroundRole), value_color)


### PR DESCRIPTION
Setting any mapping as "table name" now disables the Fixed table name check box and the name text edit. Also, setting another mapping as "table name" removes other "table name" positions.

Fixes spine-tools/Spine-Toolbox#1792

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
