### PR TITLE
Prepend Data Transformer's private config file name by '.'

### DIFF
--- a/spine_items/data_transformer/filter_config_path.py
+++ b/spine_items/data_transformer/filter_config_path.py
@@ -28,5 +28,5 @@ def filter_config_path(data_dir):
     Returns:
         str: a path to the config file
     """
-    file_name = "filter_config.json"
+    file_name = ".filter_config.json"
     return str(Path(data_dir, file_name))


### PR DESCRIPTION
Fixes spine-tools/Spine-Toolbox#1867


## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
