### PR TITLE
Exporter: Enable the "Fixed table name" check box when it is actually checked

### DIFF
--- a/spine_items/exporter/widgets/specification_editor_window.py
+++ b/spine_items/exporter/widgets/specification_editor_window.py
@@ -138,7 +138,7 @@ class SpecificationEditorWindow(SpecificationEditorWindowBase):
         """
         Args:
             toolbox (ToolboxUI): Toolbox main window
-            specification (ProjectItemSpecification, optional): exporter specification
+            specification (Specification, optional): exporter specification
             item (ProjectItem, optional): invoking project item, if window was opened from its properties tab
             url_model (QAbstractListModel): model that provides URLs of connected databases
         """
@@ -386,7 +386,9 @@ class SpecificationEditorWindow(SpecificationEditorWindowBase):
         root_mapping = current.data(MappingsTableModel.MAPPING_ROOT_ROLE)
         self._set_use_fixed_table_name_flag_silently(current.data(MappingsTableModel.USE_FIXED_TABLE_NAME_FLAG_ROLE))
         self._set_fixed_table_name_silently(current.data(MappingsTableModel.FIXED_TABLE_NAME_ROLE))
-        if any(m.position == Position.table_name for m in root_mapping.flatten()):
+        if any(
+            m.position == Position.table_name for m in root_mapping.flatten() if not isinstance(m, FixedValueMapping)
+        ):
             self._ui.fix_table_name_check_box.setEnabled(False)
             self._ui.fix_table_name_line_edit.setEnabled(False)
         self._set_group_fn_silently(group_function_display_from_name(current.data(MappingsTableModel.GROUP_FN_ROLE)))

--- a/tests/exporter/widgets/test_specification_editor_window.py
+++ b/tests/exporter/widgets/test_specification_editor_window.py
@@ -14,7 +14,10 @@ import unittest
 
 from PySide6.QtWidgets import QApplication
 
+from spine_items.exporter.specification import MappingSpecification, MappingType, Specification
 from spine_items.exporter.widgets.specification_editor_window import SpecificationEditorWindow
+from spinedb_api.export_mapping.export_mapping import FixedValueMapping, ObjectClassMapping
+from spinedb_api.mapping import Position, unflatten
 from ...mock_helpers import clean_up_toolbox, create_toolboxui_with_project
 
 
@@ -50,6 +53,18 @@ class TestSpecificationEditorWindow(unittest.TestCase):
         self.assertFalse(editor._ui.fix_table_name_check_box.isChecked())
         self.assertFalse(editor._ui.fix_table_name_line_edit.isEnabled())
         self.assertEqual(editor._ui.fix_table_name_line_edit.text(), "")
+
+    def test_mapping_with_fixed_table_enables_the_check_box_and_fills_the_table_name_field(self):
+        flattened_mappings = [FixedValueMapping(Position.table_name, "nice table name"), ObjectClassMapping(0)]
+        mapping_specification = MappingSpecification(
+            MappingType.objects, True, True, "", True, unflatten(flattened_mappings)
+        )
+        specification = Specification("spec name", mapping_specifications={"my mappings": mapping_specification})
+        editor = SpecificationEditorWindow(self._toolbox, specification)
+        self.assertTrue(editor._ui.fix_table_name_check_box.isEnabled())
+        self.assertTrue(editor._ui.fix_table_name_check_box.isChecked())
+        self.assertTrue(editor._ui.fix_table_name_line_edit.isEnabled())
+        self.assertEqual(editor._ui.fix_table_name_line_edit.text(), "nice table name")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The checkbox was accidentally disabled when the specification editor was opened with a specification that had a fixed table name.

Additional fix to spine-tools/Spine-Toolbox#1792

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
