### PR TITLE
Fix link in exporter's execution logs

### DIFF
--- a/spine_items/exporter/do_work.py
+++ b/spine_items/exporter/do_work.py
@@ -105,7 +105,10 @@ def do_work(
                         )
                     logger.msg_success.emit(f"Wrote multiple files:<br>{'<br>'.join(anchors)}")
                 else:
-                    file_anchor = f"<a style='color:#BB99FF;' title='{file}' href='file:///{file}'>{file.name}</a>"
+                    only_file = Path(next(iter(files)))
+                    file_anchor = (
+                        f"<a style='color:#BB99FF;' title='{only_file}' href='file:///{only_file}'>{only_file.name}</a>"
+                    )
                     logger.msg_success.emit(f"Wrote {file_anchor}")
                 if filter_id:
                     write_filter_id_file(filter_id, Path(out_path).parent)


### PR DESCRIPTION
The link provided to the written files was broken in certain corner cases.

Fixes spine-tools/Spine-Toolbox#1944

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
