### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -27,7 +27,6 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y unixodbc-dev
         sudo apt-get install -y libegl1
     - name: Install dependencies
       env:


### PR DESCRIPTION
Installation of the `unixodbc-dev` package is currently broken on Linux. Luckily, it's not needed.

Re spine-tools/Spine-Toolbox#1979

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
