### PR TITLE
Make execute in work a Tool setting only

### DIFF
--- a/spine_items/tool/executable_item.py
+++ b/spine_items/tool/executable_item.py
@@ -90,9 +90,9 @@ class ExecutableItem(DBWriterExecutableItemBase):
             self._tool_instance = None
 
     def _copy_input_files(self, paths, execution_dir):
-        """
-        Copies input files from given paths to work or source directory, depending on
-        where the Tool specification requires them to be.
+        """Copies input files from given paths to work or source
+        directory, depending on where the Tool specification
+        requires them to be.
 
         Args:
             paths (dict): key is path to destination file, value is path to source file
@@ -160,9 +160,9 @@ class ExecutableItem(DBWriterExecutableItemBase):
         return True
 
     def _copy_optional_input_files(self, paths, execution_dir):
-        """
-        Copies optional input files from given paths to work or source directory, depending on
-        where the Tool specification requires them to be.
+        """Copies optional input files from given paths to work or source
+        directory, depending on where the Tool specification requires
+        them to be.
 
         Args:
             paths (dict): key is the source path, value is the destination path
@@ -501,8 +501,7 @@ class ExecutableItem(DBWriterExecutableItemBase):
             )
 
     def _find_input_files(self, resources):
-        """
-        Iterates required input  files in tool specification and looks for them in the given resources.
+        """Iterates required input  files in tool specification and looks for them in the given resources.
 
         Args:
             resources (list): resources available
@@ -520,8 +519,7 @@ class ExecutableItem(DBWriterExecutableItemBase):
         return file_paths
 
     def _find_optional_input_files(self, resources):
-        """
-        Tries to find optional input files from previous project items in the DAG.
+        """Tries to find optional input files from previous project items in the DAG.
 
         Args:
             resources (list): resources available
@@ -610,8 +608,7 @@ class ExecutableItem(DBWriterExecutableItemBase):
             self._logger.msg_warning.emit(f"\tNo output files defined for this Tool specification. {tip_anchor}")
 
     def _optional_output_destination_paths(self, paths, execution_dir):
-        """
-        Returns a dictionary telling where optional output files should be copied to before execution.
+        """Returns a dictionary telling where optional output files should be copied to before execution.
 
         Args:
             paths (dict): key is the optional file name pattern, value is a list of paths to source files
@@ -680,14 +677,13 @@ class ExecutableItem(DBWriterExecutableItemBase):
 
 
 def _count_files_and_dirs(paths):
-    """
-    Counts the number of files and directories in given paths.
+    """Counts the number of files and directories in given paths.
 
     Args:
         paths (list): list of paths
 
     Returns:
-        Tuple containing the number of required files and directories.
+        tuple: Tuple containing the number of required files and directories.
     """
     n_dir = 0
     n_file = 0
@@ -717,16 +713,27 @@ def _create_output_dir_timestamp():
 
 
 def _execution_directory(work_dir, tool_specification):
-    """
-    Returns the path to the execution directory, depending on ``execute_in_work``.
+    """Returns the path to the execution directory.
 
-    If ``execute_in_work`` is ``True``, a new unique path will be returned.
-    If a main program file does not exist, Tool spec definition file path is
-    returned. Otherwise, the main program file path from tool specification
-    is returned.
+    The returned path is a new unique path when the user
+    has selected to execute the Tool in work directory.
+
+    The returned path is the directory where the Tool spec's
+    main program file is located when the user has selected
+    to execute the Tool in source directory.
+
+    The returned path is the directory where the Tool spec's
+    definition file is located when the user has selected
+    to execute the Tool in source directory and the Tool
+    spec has no main program file (it is an Executable Tool
+    spec).
+
+    Args:
+        work_dir (str): Path to work dir or None
+        tool_specification (ToolSpecification): Tool spec instance
 
     Returns:
-        str: a full path to next basedir
+        str: Full path to execution dir
     """
     if work_dir is not None:
         basedir = os.path.join(work_dir, _unique_dir_name(tool_specification))
@@ -737,12 +744,12 @@ def _execution_directory(work_dir, tool_specification):
 
 
 def _find_files_in_pattern(pattern, available_file_paths):
-    """
-    Returns a list of files that match the given pattern.
+    """Returns a list of files that match the given pattern.
 
     Args:
-        pattern (str): file pattern
-        available_file_paths (list): list of available file paths from upstream items
+        pattern (str): File pattern
+        available_file_paths (list): List of available file paths from upstream items
+
     Returns:
         list: List of (full) paths
     """

--- a/spine_items/tool/tool.py
+++ b/spine_items/tool/tool.py
@@ -209,7 +209,7 @@ class Tool(DBWriterItemBase):
         self.update_execute_in_work_button()
 
     def update_execute_in_work_button(self):
-        """Sets the execute in work radio button check state according to
+        """Sets execute in work radio button check state according to
         execute_in_work instance variable."""
         if not self._active:
             return
@@ -270,7 +270,6 @@ class Tool(DBWriterItemBase):
         if self._specification is None:
             return None
         undo_spec = self._specification.clone()
-        undo_spec.execute_in_work = self.execute_in_work
         return undo_spec
 
     def do_set_specification(self, specification):
@@ -280,8 +279,6 @@ class Tool(DBWriterItemBase):
         self._populate_cmdline_args_model()
         if self._active:
             self._update_tool_ui()
-        if specification:
-            self.do_update_execution_mode(specification.execute_in_work)
         self._resources_to_successors_changed()
         self._check_notifications()
         return True

--- a/spine_items/tool/tool_specifications.py
+++ b/spine_items/tool/tool_specifications.py
@@ -20,7 +20,6 @@ from collections import OrderedDict
 import copy
 import logging
 import os.path
-import json
 from spine_engine.project_item.project_item_specification import ProjectItemSpecification
 from spine_engine.utils.command_line_arguments import split_cmdline_args
 from .item_info import ItemInfo
@@ -39,7 +38,6 @@ OPTIONAL_KEYS = [
     "inputfiles_opt",
     "outputfiles",
     "cmdline_args",
-    "execute_in_work",
     "execution_settings",
 ]
 LIST_REQUIRED_KEYS = ["includes", "inputfiles", "inputfiles_opt", "outputfiles"]  # These should be lists
@@ -105,7 +103,6 @@ class ToolSpecification(ProjectItemSpecification):
         inputfiles_opt=None,
         outputfiles=None,
         cmdline_args=None,
-        execute_in_work=True,
     ):
         """
 
@@ -121,7 +118,6 @@ class ToolSpecification(ProjectItemSpecification):
             inputfiles_opt (list, optional): List of optional data files (wildcards may be used)
             outputfiles (list, optional): List of output files (wildcards may be used)
             cmdline_args (str, optional): Tool command line arguments (read from tool definition file)
-            execute_in_work (bool): Execute in work folder
         """
         super().__init__(name, description, item_type=ItemInfo.item_type(), item_category=ItemInfo.item_category())
         self._settings = settings
@@ -141,7 +137,6 @@ class ToolSpecification(ProjectItemSpecification):
         self.inputfiles_opt = set(inputfiles_opt) if inputfiles_opt else set()
         self.outputfiles = set(outputfiles) if outputfiles else set()
         self.return_codes = {}
-        self.execute_in_work = execute_in_work
 
     def _includes_main_path_relative(self):
         return os.path.relpath(self.path, os.path.dirname(self.definition_file_path)).replace(os.path.sep, "/")
@@ -161,7 +156,6 @@ class ToolSpecification(ProjectItemSpecification):
             "inputfiles_opt": sorted(self.inputfiles_opt),
             "outputfiles": sorted(self.outputfiles),
             "cmdline_args": self.cmdline_args,
-            "execute_in_work": self.execute_in_work,
             "includes_main_path": self._includes_main_path_relative(),
         }
 
@@ -250,7 +244,6 @@ class GAMSTool(ToolSpecification):
         inputfiles_opt=None,
         outputfiles=None,
         cmdline_args=None,
-        execute_in_work=True,
     ):
         """
 
@@ -280,7 +273,6 @@ class GAMSTool(ToolSpecification):
             inputfiles_opt,
             outputfiles,
             cmdline_args,
-            execute_in_work,
         )
         main_file = includes[0]
         # Add .lst file to list of output files
@@ -411,7 +403,6 @@ class JuliaTool(ToolSpecification):
         inputfiles_opt=None,
         outputfiles=None,
         cmdline_args=None,
-        execute_in_work=True,
     ):
         """
         Args:
@@ -440,7 +431,6 @@ class JuliaTool(ToolSpecification):
             inputfiles_opt,
             outputfiles,
             cmdline_args,
-            execute_in_work,
         )
         self.main_prgm = includes[0]
         self.julia_options = OrderedDict()
@@ -486,7 +476,6 @@ class PythonTool(ToolSpecification):
         inputfiles_opt=None,
         outputfiles=None,
         cmdline_args=None,
-        execute_in_work=True,
         execution_settings=None,
     ):
         """
@@ -518,7 +507,6 @@ class PythonTool(ToolSpecification):
             inputfiles_opt,
             outputfiles,
             cmdline_args,
-            execute_in_work,
         )
         self.main_prgm = includes[0]
         self.python_options = OrderedDict()
@@ -604,7 +592,6 @@ class ExecutableTool(ToolSpecification):
         inputfiles_opt=None,
         outputfiles=None,
         cmdline_args=None,
-        execute_in_work=True,
         execution_settings=None,
         definition_file_path=None,
     ):
@@ -639,7 +626,6 @@ class ExecutableTool(ToolSpecification):
             inputfiles_opt,
             outputfiles,
             cmdline_args,
-            execute_in_work,
         )
         try:
             self.main_prgm = includes[0]

--- a/spine_items/tool/ui/tool_specification_form.py
+++ b/spine_items/tool/ui/tool_specification_form.py
@@ -105,10 +105,11 @@ class Ui_MainWindow(object):
         sizePolicy.setHeightForWidth(self.centralwidget.sizePolicy().hasHeightForWidth())
         self.centralwidget.setSizePolicy(sizePolicy)
         self.verticalLayout_3 = QVBoxLayout(self.centralwidget)
-        self.verticalLayout_3.setSpacing(3)
+        self.verticalLayout_3.setSpacing(6)
         self.verticalLayout_3.setObjectName(u"verticalLayout_3")
-        self.verticalLayout_3.setContentsMargins(3, 3, 3, 3)
+        self.verticalLayout_3.setContentsMargins(0, 6, 0, 0)
         self.horizontalLayout_2 = QHBoxLayout()
+        self.horizontalLayout_2.setSpacing(9)
         self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
         self.horizontalLayout_2.setContentsMargins(6, -1, 6, -1)
         self.label_tooltype = QLabel(self.centralwidget)
@@ -124,13 +125,6 @@ class Ui_MainWindow(object):
         self.comboBox_tooltype.setMaximumSize(QSize(16777215, 24))
 
         self.horizontalLayout_2.addWidget(self.comboBox_tooltype)
-
-        self.line = QFrame(self.centralwidget)
-        self.line.setObjectName(u"line")
-        self.line.setFrameShape(QFrame.VLine)
-        self.line.setFrameShadow(QFrame.Sunken)
-
-        self.horizontalLayout_2.addWidget(self.line)
 
         self.label_3 = QLabel(self.centralwidget)
         self.label_3.setObjectName(u"label_3")
@@ -308,7 +302,7 @@ class Ui_MainWindow(object):
         self.comboBox_tooltype.setToolTip(QCoreApplication.translate("MainWindow", u"<html><head/><body><p>Tool specification type</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.comboBox_tooltype.setCurrentText("")
-        self.label_3.setText(QCoreApplication.translate("MainWindow", u"Command line arguments:", None))
+        self.label_3.setText(QCoreApplication.translate("MainWindow", u"Command line arguments", None))
 #if QT_CONFIG(tooltip)
         self.lineEdit_args.setToolTip(QCoreApplication.translate("MainWindow", u"<html><head/><body><p>Command line arguments (space-delimited) for the main program (optional). Use '@@' tags to refer to input files or URLs, see the User Guide for details.</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)

--- a/spine_items/tool/ui/tool_specification_form.py
+++ b/spine_items/tool/ui/tool_specification_form.py
@@ -26,10 +26,10 @@ from PySide6.QtGui import (QAction, QBrush, QColor, QConicalGradient,
     QIcon, QImage, QKeySequence, QLinearGradient,
     QPainter, QPalette, QPixmap, QRadialGradient,
     QTransform)
-from PySide6.QtWidgets import (QAbstractItemView, QApplication, QCheckBox, QComboBox,
-    QDockWidget, QFrame, QHBoxLayout, QHeaderView,
-    QLabel, QLineEdit, QMainWindow, QSizePolicy,
-    QStatusBar, QVBoxLayout, QWidget)
+from PySide6.QtWidgets import (QAbstractItemView, QApplication, QComboBox, QDockWidget,
+    QFrame, QHBoxLayout, QHeaderView, QLabel,
+    QLineEdit, QMainWindow, QSizePolicy, QStatusBar,
+    QVBoxLayout, QWidget)
 
 from spinetoolbox.widgets.code_text_edit import CodeTextEdit
 from spinetoolbox.widgets.custom_qtreeview import (CustomTreeView, SourcesTreeView)
@@ -124,19 +124,6 @@ class Ui_MainWindow(object):
         self.comboBox_tooltype.setMaximumSize(QSize(16777215, 24))
 
         self.horizontalLayout_2.addWidget(self.comboBox_tooltype)
-
-        self.line_3 = QFrame(self.centralwidget)
-        self.line_3.setObjectName(u"line_3")
-        self.line_3.setFrameShape(QFrame.VLine)
-        self.line_3.setFrameShadow(QFrame.Sunken)
-
-        self.horizontalLayout_2.addWidget(self.line_3)
-
-        self.checkBox_execute_in_work = QCheckBox(self.centralwidget)
-        self.checkBox_execute_in_work.setObjectName(u"checkBox_execute_in_work")
-        self.checkBox_execute_in_work.setChecked(True)
-
-        self.horizontalLayout_2.addWidget(self.checkBox_execute_in_work)
 
         self.line = QFrame(self.centralwidget)
         self.line.setObjectName(u"line")
@@ -321,10 +308,6 @@ class Ui_MainWindow(object):
         self.comboBox_tooltype.setToolTip(QCoreApplication.translate("MainWindow", u"<html><head/><body><p>Tool specification type</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.comboBox_tooltype.setCurrentText("")
-#if QT_CONFIG(tooltip)
-        self.checkBox_execute_in_work.setToolTip(QCoreApplication.translate("MainWindow", u"<html><head/><body><p>If checked, Tool specification is executed in a work directory (default).</p><p>If unchecked, Tool specification is executed in main program file directory.</p><p>It is recommended to uncheck this for <span style=\" font-weight:600;\">Executable</span> Tool specifications.</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.checkBox_execute_in_work.setText(QCoreApplication.translate("MainWindow", u"Execute in work directory", None))
         self.label_3.setText(QCoreApplication.translate("MainWindow", u"Command line arguments:", None))
 #if QT_CONFIG(tooltip)
         self.lineEdit_args.setToolTip(QCoreApplication.translate("MainWindow", u"<html><head/><body><p>Command line arguments (space-delimited) for the main program (optional). Use '@@' tags to refer to input files or URLs, see the User Guide for details.</p></body></html>", None))

--- a/spine_items/tool/ui/tool_specification_form.ui
+++ b/spine_items/tool/ui/tool_specification_form.ui
@@ -95,26 +95,6 @@
        </widget>
       </item>
       <item>
-       <widget class="Line" name="line_3">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="checkBox_execute_in_work">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, Tool specification is executed in a work directory (default).&lt;/p&gt;&lt;p&gt;If unchecked, Tool specification is executed in main program file directory.&lt;/p&gt;&lt;p&gt;It is recommended to uncheck this for &lt;span style=&quot; font-weight:600;&quot;&gt;Executable&lt;/span&gt; Tool specifications.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Execute in work directory</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="Line" name="line">
         <property name="orientation">
          <enum>Qt::Vertical</enum>

--- a/spine_items/tool/ui/tool_specification_form.ui
+++ b/spine_items/tool/ui/tool_specification_form.ui
@@ -37,22 +37,25 @@
    </property>
    <layout class="QVBoxLayout" name="verticalLayout_3">
     <property name="spacing">
-     <number>3</number>
+     <number>6</number>
     </property>
     <property name="leftMargin">
-     <number>3</number>
+     <number>0</number>
     </property>
     <property name="topMargin">
-     <number>3</number>
+     <number>6</number>
     </property>
     <property name="rightMargin">
-     <number>3</number>
+     <number>0</number>
     </property>
     <property name="bottomMargin">
-     <number>3</number>
+     <number>0</number>
     </property>
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="spacing">
+       <number>9</number>
+      </property>
       <property name="leftMargin">
        <number>6</number>
       </property>
@@ -95,16 +98,9 @@
        </widget>
       </item>
       <item>
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Command line arguments:</string>
+         <string>Command line arguments</string>
         </property>
        </widget>
       </item>

--- a/spine_items/tool/widgets/tool_specification_editor_window.py
+++ b/spine_items/tool/widgets/tool_specification_editor_window.py
@@ -78,7 +78,6 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
         self._ui.comboBox_tooltype.setCurrentIndex(-1)
         # if a specification is given, fill the form with data from it
         if specification is not None:
-            self._ui.checkBox_execute_in_work.setChecked(specification.execute_in_work)
             self._ui.lineEdit_args.setText(" ".join(specification.cmdline_args))
             tooltype = specification.tooltype.lower()
             index = next(iter(k for k, t in enumerate(TOOL_TYPES) if t.lower() == tooltype), -1)
@@ -212,7 +211,6 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
         else:
             self.includes_main_path = os.path.abspath(main_prgm_dir)
         self._label_main_path.setText(self.includes_main_path)
-        new_spec_dict["execute_in_work"] = self._ui.checkBox_execute_in_work.isChecked()
         new_spec_dict["includes"] = [main_prgm_file_name] if main_prgm_file_name else []
         new_spec_dict["includes"] += self._additional_program_file_list()
         new_spec_dict["inputfiles"] = self._input_file_list()
@@ -483,7 +481,6 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
         # Push undo commands
         self._ui.comboBox_tooltype.currentIndexChanged.connect(self._push_change_tooltype_command)
         self._ui.comboBox_tooltype.currentIndexChanged.connect(self._show_optional_widget)
-        self._ui.checkBox_execute_in_work.toggled.connect(self._push_change_execute_in_work_command)
         self._ui.lineEdit_args.editingFinished.connect(self._push_change_args_command)
         self.io_files_model.dataChanged.connect(self._push_io_file_renamed_command)
         # Selection changed
@@ -607,19 +604,6 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
         opt_widget = self._get_optional_widget("executable")
         index = next(iter(k for k, t in enumerate(opt_widget.shells) if t.lower() == value), 0)
         opt_widget.ui.comboBox_shell.setCurrentIndex(index)
-
-    @Slot(bool)
-    def _push_change_execute_in_work_command(self, new_value):
-        old_value = self.spec_dict.get("execute_in_work", True)
-        if new_value == old_value:
-            return
-        self._undo_stack.push(
-            ChangeSpecPropertyCommand(self._set_execute_in_work, new_value, old_value, "change execute in work")
-        )
-
-    def _set_execute_in_work(self, value):
-        self.spec_dict["execute_in_work"] = value
-        self._ui.checkBox_execute_in_work.setChecked(value)
 
     @Slot()
     def _push_change_args_command(self):

--- a/tests/tool/test_Tool.py
+++ b/tests/tool/test_Tool.py
@@ -172,6 +172,7 @@ class TestTool(unittest.TestCase):
             self._assert_is_no_tool(tool)
             # Set the simple_exec tool specification manually
             tool._properties_ui.comboBox_tool.textActivated.emit("simple_exec")
+            tool._properties_ui.radioButton_execute_in_source.setChecked(True)
             self._assert_is_simple_exec_tool(tool)
             tool.deactivate()
             tool.activate()

--- a/tests/tool/test_Tool.py
+++ b/tests/tool/test_Tool.py
@@ -49,7 +49,6 @@ class TestTool(unittest.TestCase):
                 inputfiles_opt=["opt_input.csv"],
                 outputfiles=["output1.csv", "output2.csv"],
                 cmdline_args="<args>",
-                execute_in_work=False,
             ),
             ExecutableTool(
                 name="complex_exec",
@@ -63,7 +62,6 @@ class TestTool(unittest.TestCase):
                 inputfiles_opt=["opt/*.ini", "?abc.txt"],
                 outputfiles=["output1.csv", "output/output2.csv"],
                 cmdline_args="subunit",
-                execute_in_work=True,
             ),
         ]
         self.specification_dict = {x.name: x for x in specifications}

--- a/tests/tool/test_ToolExecutable.py
+++ b/tests/tool/test_ToolExecutable.py
@@ -63,7 +63,6 @@ class TestToolExecutable(unittest.TestCase):
             includes=script_files,
             settings=mock_settings,
             logger=mock.MagicMock(),
-            execute_in_work=True,
         )
         specs_in_project = {"Tool": {"Python Tool": python_tool_spec}}
         temp_project_dir = str(pathlib.Path(self._temp_dir.name, "project"))

--- a/tests/tool/test_tool_instance.py
+++ b/tests/tool/test_tool_instance.py
@@ -40,22 +40,20 @@ class TestPythonToolInstance(unittest.TestCase):
             instance.prepare([])
         self.assertEqual(instance.args, ['%cd -q path/', '%run "main.py"'])
 
-    @unittest.skip("It get's stuck waiting for the persistent process to interrupt")
     def test_prepare_with_cmd_line_arguments_in_persistent_process(self):
         instance = self._make_tool_instance(False)
         with mock.patch("spine_engine.execution_managers.persistent_execution_manager.PersistentManagerBase"):
             instance.prepare(["arg1", "arg2"])
         self.assertEqual(instance.program, [sys.executable])
-        self.assertEqual(instance.exec_mngr.alias, "# Running 'python main.py arg1 arg2'")
+        self.assertEqual(instance.exec_mngr.alias, "python main.py arg1 arg2")
         instance.terminate_instance()
 
-    @unittest.skip("It get's stuck waiting for the persistent process to interrupt")
     def test_prepare_without_cmd_line_arguments_in_persistent_process(self):
         instance = self._make_tool_instance(False)
         with mock.patch("spine_engine.execution_managers.persistent_execution_manager.PersistentManagerBase"):
             instance.prepare([])
         self.assertEqual(instance.program, [sys.executable])
-        self.assertEqual(instance.exec_mngr.alias, "# Running 'python main.py'")
+        self.assertEqual(instance.exec_mngr.alias, "python main.py")
         instance.terminate_instance()
 
     @staticmethod

--- a/tests/tool/test_tool_specifications.py
+++ b/tests/tool/test_tool_specifications.py
@@ -30,7 +30,6 @@ class TestToolSpecification(unittest.TestCase):
             ["*.dat", "a.csv", "z.zip", "*.xlsx"],
             ["*.zip", "*.atk"],
             ["99", "10"],
-            execute_in_work=False,
         )
         specification.definition_file_path = "/path/to/specification/file.json"
         specification_dict = specification.to_dict()
@@ -45,7 +44,6 @@ class TestToolSpecification(unittest.TestCase):
                 "inputfiles_opt": ["*.dat", "*.xlsx", "a.csv", "z.zip"],
                 "outputfiles": ["*.atk", "*.zip"],
                 "cmdline_args": ["99", "10"],
-                "execute_in_work": False,
                 "includes_main_path": "../tool",
             },
         )


### PR DESCRIPTION
This PR removes all references to **Tool Specs'** 'execute_in_work' setting, and the 'Execute in work' check box in Tool Specification Editor.

Re spine-tools/Spine-Toolbox#884

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
