### PR TITLE
Add option to Tool to kill executed console processes

### DIFF
--- a/spine_items/tool/commands.py
+++ b/spine_items/tool/commands.py
@@ -60,3 +60,23 @@ class UpdateToolOptionsCommand(SpineToolboxCommand):
 
     def undo(self):
         self.tool.do_set_options(self.old_options)
+
+
+class UpdateKillCompletedProcesses(SpineToolboxCommand):
+    def __init__(self, tool, kill_completed_processes):
+        """Command to update Tool kill_completed_processes flag.
+
+        Args:
+            tool (Tool): the Tool
+            kill_completed_processes (bool): new flag value
+        """
+        super().__init__()
+        self._tool = tool
+        self._kill_completed_processes = kill_completed_processes
+        self.setText(f"change kill consoles setting of {tool.name}")
+
+    def redo(self):
+        self._tool.do_update_kill_completed_processes(self._kill_completed_processes)
+
+    def undo(self):
+        self._tool.do_update_kill_completed_processes(not self._kill_completed_processes)

--- a/spine_items/tool/tool_instance.py
+++ b/spine_items/tool/tool_instance.py
@@ -140,6 +140,19 @@ class GAMSToolInstance(ToolInstance):
 class JuliaToolInstance(ToolInstance):
     """Class for Julia Tool instances."""
 
+    def __init__(self, tool_specification, basedir, settings, kill_completed_processes, logger, owner):
+        """
+        Args:
+            tool_specification (ToolSpecification): the tool specification for this instance
+            basedir (str): the path to the directory where this instance should run
+            settings (QSettings): Toolbox settings
+            kill_completed_processes (bool): whether to kill completed persistent processes
+            logger (LoggerInterface): a logger instance
+            owner (ExecutableItemBase): The item that owns the instance
+        """
+        super().__init__(tool_specification, basedir, settings, logger, owner)
+        self._kill_completed_processes = kill_completed_processes
+
     def prepare(self, args):
         """See base class."""
         sysimage = self._owner.options.get("julia_sysimage", "")
@@ -187,7 +200,7 @@ class JuliaToolInstance(ToolInstance):
             self.program.append(f"--sysimage={sysimage}")
         alias = f"julia {' '.join([self.tool_specification.main_prgm, *cmdline_args])}"
         self.exec_mngr = JuliaPersistentExecutionManager(
-            self._logger, self.program, self.args, alias, group_id=self.owner.group_id
+            self._logger, self.program, self.args, alias, self._kill_completed_processes, self.owner.group_id
         )
 
     def execute(self):
@@ -206,6 +219,19 @@ class JuliaToolInstance(ToolInstance):
 
 class PythonToolInstance(ToolInstance):
     """Class for Python Tool instances."""
+
+    def __init__(self, tool_specification, basedir, settings, kill_completed_processes, logger, owner):
+        """
+        Args:
+            tool_specification (ToolSpecification): the tool specification for this instance
+            basedir (str): the path to the directory where this instance should run
+            settings (QSettings): Toolbox settings
+            kill_completed_processes (bool): whether to kill completed persistent processes
+            logger (LoggerInterface): a logger instance
+            owner (ExecutableItemBase): The item that owns the instance
+        """
+        super().__init__(tool_specification, basedir, settings, logger, owner)
+        self._kill_completed_processes = kill_completed_processes
 
     def prepare(self, args):
         """See base class."""
@@ -248,7 +274,7 @@ class PythonToolInstance(ToolInstance):
             self.args += self._make_exec_code(fp, full_fp)
             alias = f"python {' '.join([self.tool_specification.main_prgm, *cmdline_args[1:]])}"
             self.exec_mngr = PythonPersistentExecutionManager(
-                self._logger, self.program, self.args, alias, group_id=self.owner.group_id
+                self._logger, self.program, self.args, alias, self._kill_completed_processes, self.owner.group_id
             )
 
     @staticmethod

--- a/spine_items/tool/tool_specifications.py
+++ b/spine_items/tool/tool_specifications.py
@@ -217,11 +217,12 @@ class ToolSpecification(ProjectItemSpecification):
                     pass
         return kwargs
 
-    def create_tool_instance(self, basedir, logger, owner):
+    def create_tool_instance(self, basedir, kill_completed_processes, logger, owner):
         """Returns an instance of this tool specification that is configured to run in the given directory.
 
         Args:
             basedir (str): Path to the directory where the instance will run
+            kill_completed_processes (bool): whether to kill completed persistent processes
             logger (LoggerInterface): Logger
             owner (ExecutableItemBase): Project item that owns the instance
         """
@@ -382,7 +383,7 @@ class GAMSTool(ToolSpecification):
             return GAMSTool(path=path, settings=settings, logger=logger, **kwargs)
         return None
 
-    def create_tool_instance(self, basedir, logger, owner):
+    def create_tool_instance(self, basedir, kill_completed_processes, logger, owner):
         """See base class."""
         return GAMSToolInstance(self, basedir, self._settings, logger, owner)
 
@@ -455,9 +456,9 @@ class JuliaTool(ToolSpecification):
             return JuliaTool(path=path, settings=settings, logger=logger, **kwargs)
         return None
 
-    def create_tool_instance(self, basedir, logger, owner):
+    def create_tool_instance(self, basedir, kill_completed_processes, logger, owner):
         """See base class."""
-        return JuliaToolInstance(self, basedir, self._settings, logger, owner)
+        return JuliaToolInstance(self, basedir, self._settings, kill_completed_processes, logger, owner)
 
 
 class PythonTool(ToolSpecification):
@@ -571,9 +572,9 @@ class PythonTool(ToolSpecification):
             return PythonTool(path=path, settings=settings, logger=logger, **kwargs)
         return None
 
-    def create_tool_instance(self, basedir, logger, owner):
+    def create_tool_instance(self, basedir, kill_completed_processes, logger, owner):
         """See base class."""
-        return PythonToolInstance(self, basedir, self._settings, logger, owner)
+        return PythonToolInstance(self, basedir, self._settings, kill_completed_processes, logger, owner)
 
 
 class ExecutableTool(ToolSpecification):
@@ -696,6 +697,6 @@ class ExecutableTool(ToolSpecification):
             return ExecutableTool(path=path, settings=settings, logger=logger, **kwargs)
         return None
 
-    def create_tool_instance(self, basedir, logger, owner):
+    def create_tool_instance(self, basedir, kill_completed_processes, logger, owner):
         """See base class."""
         return ExecutableToolInstance(self, basedir, self._settings, logger, owner)

--- a/spine_items/tool/ui/tool_properties.py
+++ b/spine_items/tool/ui/tool_properties.py
@@ -25,11 +25,11 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
-from PySide6.QtWidgets import (QAbstractItemView, QApplication, QComboBox, QFrame,
-    QGridLayout, QHBoxLayout, QHeaderView, QLabel,
-    QLineEdit, QPushButton, QRadioButton, QSizePolicy,
-    QSpacerItem, QSplitter, QToolButton, QTreeView,
-    QVBoxLayout, QWidget)
+from PySide6.QtWidgets import (QAbstractItemView, QApplication, QCheckBox, QComboBox,
+    QFrame, QGridLayout, QHBoxLayout, QHeaderView,
+    QLabel, QLineEdit, QPushButton, QRadioButton,
+    QSizePolicy, QSpacerItem, QSplitter, QToolButton,
+    QTreeView, QVBoxLayout, QWidget)
 
 from ...widgets import ArgsTreeView
 from spinetoolbox.widgets.custom_qwidgets import ElidedLabel
@@ -85,7 +85,7 @@ class Ui_Form(object):
 
         self.splitter = QSplitter(Form)
         self.splitter.setObjectName(u"splitter")
-        self.splitter.setOrientation(Qt.Orientation.Vertical)
+        self.splitter.setOrientation(Qt.Vertical)
         self.treeView_cmdline_args = ArgsTreeView(self.splitter)
         self.treeView_cmdline_args.setObjectName(u"treeView_cmdline_args")
         sizePolicy2 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
@@ -191,6 +191,11 @@ class Ui_Form(object):
 
         self.verticalLayout_2.addWidget(self.label_jupyter)
 
+        self.kill_consoles_check_box = QCheckBox(self.frame)
+        self.kill_consoles_check_box.setObjectName(u"kill_consoles_check_box")
+
+        self.verticalLayout_2.addWidget(self.kill_consoles_check_box)
+
 
         self.verticalLayout.addWidget(self.frame)
 
@@ -247,6 +252,10 @@ class Ui_Form(object):
         self.lineEdit_group_id.setToolTip(QCoreApplication.translate("Form", u"<html><head/><body><p>Type execution group identifier, or leave empty to run in isolation.</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.label_jupyter.setText(QCoreApplication.translate("Form", u"Console info", None))
+#if QT_CONFIG(tooltip)
+        self.kill_consoles_check_box.setToolTip(QCoreApplication.translate("Form", u"If checked, console processes will be killed automatically after execution finishes freeing memory and other resources.", None))
+#endif // QT_CONFIG(tooltip)
+        self.kill_consoles_check_box.setText(QCoreApplication.translate("Form", u"Kill consoles at the end of execution", None))
 #if QT_CONFIG(tooltip)
         self.pushButton_tool_results.setToolTip(QCoreApplication.translate("Form", u"<html><head/><body><p>Open results archive in file browser</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)

--- a/spine_items/tool/ui/tool_properties.ui
+++ b/spine_items/tool/ui/tool_properties.ui
@@ -256,6 +256,16 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="kill_consoles_check_box">
+        <property name="toolTip">
+         <string>If checked, console processes will be killed automatically after execution finishes freeing memory and other resources.</string>
+        </property>
+        <property name="text">
+         <string>Kill consoles at the end of execution</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/tests/tool/test_ToolExecutable.py
+++ b/tests/tool/test_ToolExecutable.py
@@ -135,6 +135,7 @@ class TestToolExecutable(unittest.TestCase):
             tool_specification=None,
             cmd_line_args=[],
             options={},
+            kill_completed_processes=False,
             group_id=None,
             project_dir=self._temp_dir.name,
             logger=logger,
@@ -155,7 +156,7 @@ class TestToolExecutable(unittest.TestCase):
         work_dir = pathlib.Path(self._temp_dir.name, "work")
         work_dir.mkdir()
         executable = ExecutableItem(
-            "Create files", str(work_dir), tool_specification, [], {}, None, self._temp_dir.name, logger
+            "Create files", str(work_dir), tool_specification, [], {}, False, None, self._temp_dir.name, logger
         )
         executable.execute([], [], Lock())
         while executable._tool_instance is not None:
@@ -182,6 +183,7 @@ class TestToolExecutable(unittest.TestCase):
             tool_specification=tool_specification,
             cmd_line_args=[],
             options={},
+            kill_completed_processes=False,
             group_id=None,
             project_dir=self._temp_dir.name,
             logger=logger,
@@ -213,6 +215,7 @@ class TestToolExecutable(unittest.TestCase):
             tool_specification=tool_specification,
             cmd_line_args=[],
             options={},
+            kill_completed_processes=False,
             group_id=None,
             project_dir=self._temp_dir.name,
             logger=logger,
@@ -245,6 +248,7 @@ class TestToolExecutable(unittest.TestCase):
             tool_specification=tool_specification,
             cmd_line_args=[],
             options={},
+            kill_completed_processes=False,
             group_id=None,
             project_dir=self._temp_dir.name,
             logger=logger,
@@ -271,7 +275,7 @@ class TestToolExecutable(unittest.TestCase):
             outputfiles=["results.gdx", "report.txt"],
         )
         executable = ExecutableItem(
-            "name", self._temp_dir.name, tool_specification, [], {}, None, self._temp_dir.name, logger
+            "name", self._temp_dir.name, tool_specification, [], {}, False, None, self._temp_dir.name, logger
         )
         output_dir = pathlib.Path(executable._data_dir, "output")
         output_dir.mkdir()
@@ -304,10 +308,10 @@ class TestToolExecutable(unittest.TestCase):
             outputfiles=["results.gdx", "report.txt"],
         )
         executable = ExecutableItem(
-            "name", self._temp_dir.name, tool_specification, [], {}, None, self._temp_dir.name, logger
+            "name", self._temp_dir.name, tool_specification, [], {}, False, None, self._temp_dir.name, logger
         )
         executable._tool_instance = executable._tool_specification.create_tool_instance(
-            self._temp_dir.name, "name", mock.MagicMock()
+            self._temp_dir.name, False, logger, mock.MagicMock()
         )
         executable._tool_instance.exec_mngr = mock.MagicMock()
         executable.stop_execution()

--- a/tests/tool/test_tool_instance.py
+++ b/tests/tool/test_tool_instance.py
@@ -74,7 +74,7 @@ class TestPythonToolInstance(unittest.TestCase):
         source_files = ["main.py"]
         specification = PythonTool("specification name", "python", path, source_files, settings, logger)
         base_directory = "path/"
-        return specification.create_tool_instance(base_directory, logger, mock.Mock())
+        return specification.create_tool_instance(base_directory, False, logger, mock.Mock())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds an option to Tool that allows killing persistent Julia and Python consoles when execution finishes.

Re spine-tools/Spine-Toolbox#1586

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
