### PR TITLE
split actions by dialect type

### DIFF
--- a/spine_items/data_store/data_store.py
+++ b/spine_items/data_store/data_store.py
@@ -327,6 +327,7 @@ class DataStore(ProjectItem):
             if not sqlite_file_creation_successful:  # User cancelled
                 return
         elif self._url["dialect"] == "mysql":
+            sa_url = convert_to_sqlalchemy_url(self._url, self.name, self._logger)
             if sa_url:
                 self._toolbox.db_mngr.create_new_spine_database(sa_url, self._logger)
         else:

--- a/spine_items/data_store/data_store.py
+++ b/spine_items/data_store/data_store.py
@@ -322,13 +322,15 @@ class DataStore(ProjectItem):
     @Slot(bool)
     def create_new_spine_database(self, checked=False):
         """Create new (empty) Spine database."""
-        # Try to make an url from the current status
-        sa_url = convert_to_sqlalchemy_url(self._url, self.name, self._logger)
-        if not sa_url:
-            if self._url["dialect"] != "sqlite" or not self._new_sqlite_file():
+        if self._url["dialect"] == "sqlite":
+            sqlite_file_creation_successful = self._new_sqlite_file()
+            if not sqlite_file_creation_successful:  # User cancelled
                 return
+        elif self._url["dialect"] == "mysql":
+            if sa_url:
+                self._toolbox.db_mngr.create_new_spine_database(sa_url, self._logger)
         else:
-            self._toolbox.db_mngr.create_new_spine_database(sa_url, self._logger)
+            self._logger.msg_error.emit(f"Unknown data store dialect: {self._url['dialect']}.")
         self._check_notifications()
 
     def _check_notifications(self):


### PR DESCRIPTION
Error handling is currently done by emitting the errors where they happen. If it is a benign/expected error, the logger is set to `None` to suppress the output. This poses problems when a function could both raise benign and real errors, as in spine-tools/Spine-Toolbox#2014 . This patch fixes the issue locally, but a more robust error handling would be beneficial in the long term, see spine-tools/Spine-Toolbox#2041 .

No documentation needs to be updated.
Code changes are checked with `black`.
Unit tests pass.

Fixes spine-tools/Spine-Toolbox#2014

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
