### PR TITLE
Don't hide Importer's source tables

### DIFF
--- a/spine_items/importer/widgets/import_editor_window.py
+++ b/spine_items/importer/widgets/import_editor_window.py
@@ -124,6 +124,11 @@ class ImportEditorWindow(SpecificationEditorWindowBase):
     def settings_group(self):
         return "mappingPreviewWindow"
 
+    def _save(self):
+        """See base class."""
+        if super()._save():
+            self._import_mappings.specification_saved()
+
     @property
     def _duplicate_kwargs(self):
         return dict(filepath=self._filepath)

--- a/spine_items/importer/widgets/import_mappings.py
+++ b/spine_items/importer/widgets/import_mappings.py
@@ -71,6 +71,10 @@ class ImportMappings:
         self._ui.duplicate_button.clicked.connect(self._duplicate_selected_mapping)
         self._ui.mapping_list.customContextMenuRequested.connect(self._show_mapping_list_context_menu)
 
+    def specification_saved(self):
+        """Notifies mappings model items that they have been stored into the specification."""
+        self._mappings_model.set_source_table_items_into_specification()
+
     @Slot(QModelIndex, QModelIndex)
     def _change_list(self, current, previous):
         """Loads current source table's mapping list.

--- a/spine_items/importer/widgets/import_sources.py
+++ b/spine_items/importer/widgets/import_sources.py
@@ -283,20 +283,18 @@ class ImportSources(QObject):
         Args:
             tables (dict): updated source tables
         """
-        is_file_less = self.parent().is_file_less()
-        if is_file_less:
+        if self.parent().is_file_less():
             self._mappings_model.add_empty_row()
             return
-        for row in reversed(range(1, self._mappings_model.rowCount())):
-            if self._mappings_model.index(row, 0).data() not in tables:
-                self._mappings_model.removeRow(row)
+        selection_model = self._ui.source_list.selectionModel()
+        current_row = selection_model.currentIndex().row()
+        self._mappings_model.cross_check_source_table_names(set(tables))
+        self._mappings_model.remove_tables_not_in_source_and_specification()
         table_names = set(self._mappings_model.real_table_names())
         for t_name, t_mapping in tables.items():
             if t_name not in table_names:
                 self._mappings_model.append_new_table_with_mapping(t_name, t_mapping)
         # reselect current table if existing otherwise select first table
-        selection_model = self._ui.source_list.selectionModel()
-        current_row = selection_model.currentIndex().row()
         selection_model.setCurrentIndex(QModelIndex(), QItemSelectionModel.ClearAndSelect)
         if current_row >= 0:
             self._select_table_row(min(current_row, self._mappings_model.rowCount() - 1))

--- a/tests/importer/widgets/test_import_sources.py
+++ b/tests/importer/widgets/test_import_sources.py
@@ -14,7 +14,7 @@ from unittest import mock
 
 from PySide6.QtCore import QModelIndex
 from PySide6.QtGui import QUndoStack
-from PySide6.QtWidgets import QApplication, QWidget
+from PySide6.QtWidgets import QApplication, QListWidget, QWidget
 
 from spine_items.importer.connection_manager import ConnectionManager
 from spine_items.importer.mvcmodels.mappings_model import MappingsModel
@@ -47,6 +47,7 @@ class TestImportSources(unittest.TestCase):
         source_list_index.row.return_value = 0
         source_list_selection_model.currentIndex.return_value = source_list_index
         ui.source_list.selectionModel.return_value = source_list_selection_model
+        ui.mapping_list = QListWidget(self._parent_widget)
         import_sources = ImportSources(self._mappings_model, ui, self._undo_stack, self._parent_widget)
         data = []
         connection_settings = {"data": data}
@@ -86,6 +87,7 @@ class TestImportSources(unittest.TestCase):
         source_list_index.row.return_value = 0
         source_list_selection_model.currentIndex.return_value = source_list_index
         ui.source_list.selectionModel.return_value = source_list_selection_model
+        ui.mapping_list = QListWidget(self._parent_widget)
         import_sources = ImportSources(self._mappings_model, ui, self._undo_stack, self._parent_widget)
         data = [["data 1", "data 2"]]
         connection_settings = {"data": data}
@@ -125,6 +127,7 @@ class TestImportSources(unittest.TestCase):
         source_list_index.row.return_value = 0
         source_list_selection_model.currentIndex.return_value = source_list_index
         ui.source_list.selectionModel.return_value = source_list_selection_model
+        ui.mapping_list = QListWidget(self._parent_widget)
         import_sources = ImportSources(self._mappings_model, ui, self._undo_stack, self._parent_widget)
         data = [["header 1", "header 2"]]
         connection_settings = {"data": data}
@@ -164,6 +167,7 @@ class TestImportSources(unittest.TestCase):
         source_list_index.row.return_value = 0
         source_list_selection_model.currentIndex.return_value = source_list_index
         ui.source_list.selectionModel.return_value = source_list_selection_model
+        ui.mapping_list = QListWidget(self._parent_widget)
         import_sources = ImportSources(self._mappings_model, ui, self._undo_stack, self._parent_widget)
         data = [["header 1", "header 2"], ["data 1", "data 2"]]
         connection_settings = {"data": data}


### PR DESCRIPTION
This PR improves the visuals of Importer specification editor's Source tables list. Most importantly, we don't hide tables that are in the specification but don't exist in the source. Instead, the tables are grayed out with a tooltip explaining the situation. Also, tables that have been found in the source but do not yet have entries in the specification get a '(new)' token appended to their names. This will hopefully make it easier to spot mappings that need attention when the source changes.

Fixes spine-tools/Spine-Toolbox#1608

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
