### PR TITLE
Fix resource advertisement in Data store

### DIFF
--- a/tests/data_store/test_dataStore.py
+++ b/tests/data_store/test_dataStore.py
@@ -334,6 +334,8 @@ class TestDataStoreWithMockToolbox(unittest.TestCase):
         self.ds.do_update_url(dialect="sqlite", database=database_1)
         self.project.notify_resource_changes_to_predecessors.assert_called_once_with(self.ds)
         self.project.notify_resource_changes_to_successors.assert_called_once_with(self.ds)
+        while not self.ds.is_url_validated():
+            QApplication.processEvents()
         database_2 = os.path.join(self._temp_dir.name, "db2.sqlite")
         Path(database_2).touch()
         self.ds.do_update_url(dialect="sqlite", database=database_2)


### PR DESCRIPTION
Data store doesn't advertise its resources if the URL is invalid. If user fixes the URL, Data store should advertise the fixed URL as a new resource, not as replacement to an old one (which was never broadcast to other items).


Fixes spine-tools/Spine-Toolbox#2060

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
