### PR TITLE
Add a *.* file selection option to Importer

### DIFF
--- a/spine_items/importer/widgets/import_editor_window.py
+++ b/spine_items/importer/widgets/import_editor_window.py
@@ -199,7 +199,7 @@ class ImportEditorWindow(SpecificationEditorWindowBase):
         return selector.url
 
     def _get_source_file_path(self):
-        filter_ = ";;".join([conn.FILE_EXTENSIONS for conn in _CONNECTOR_NAME_TO_CLASS.values()])
+        filter_ = ";;".join([conn.FILE_EXTENSIONS for conn in _CONNECTOR_NAME_TO_CLASS.values()]) + ";;*.*"
         key = f"selectInputDataFileFor{self.specification.name if self.specification else None}"
         filepath, _ = get_open_file_name_in_last_dir(
             self._toolbox.qsettings(),


### PR DESCRIPTION
Adds a `*.*` selection option when selecting file to import, as per https://github.com/spine-tools/Spine-Toolbox/issues/2039#issuecomment-1514149925.

Fixes spine-tools/Spine-Toolbox#2039

## Checklist before merging
- [ ] ~Documentation (also in Toolbox repo) is up-to-date~ N/A
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
