### PR TITLE
Fix Importer's Source options widget

### DIFF
--- a/spine_items/importer/widgets/options_widget.py
+++ b/spine_items/importer/widgets/options_widget.py
@@ -115,7 +115,7 @@ class OptionsWidget(QWidget):
             connector (ConnectionManager): connector
         """
         self._connector = connector
-        self._options = connector.connection.BASE_OPTIONS
+        self._options = connector.connection.BASE_OPTIONS.copy()
         self._options.update(connector.connection.OPTIONS)
         connector.current_table_changed.connect(self._fetch_options_from_connector)
         self.options_changed.connect(connector.update_options)

--- a/tests/importer/widgets/test_OptionsWidget.py
+++ b/tests/importer/widgets/test_OptionsWidget.py
@@ -99,6 +99,17 @@ class TestOptionsWidget(unittest.TestCase):
                 break
         self.assertTrue(checked)
 
+    def test_set_connector_makes_copy_of_connections_base_options(self):
+        option_template = {"yesno": {"label": "check me", "type": bool, "default": True}}
+        connector = MagicMock()
+        connector.connection.BASE_OPTIONS = {"text": {"label": "text value", "type": str, "default": ""}}
+        connector.connection.OPTIONS = option_template
+        widget = OptionsWidget(self._undo_stack)
+        widget.set_connector(connector)
+        self.assertEqual(
+            connector.connection.BASE_OPTIONS, {"text": {"label": "text value", "type": str, "default": ""}}
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes the duplicate options in Importer's Source options dock.

Fixes spine-tools/Spine-Toolbox#2106

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
