### PR TITLE
Update exporter according to mapping changes in spinedb_api

### DIFF
--- a/spine_items/exporter/mvcmodels/mapping_editor_table_model.py
+++ b/spine_items/exporter/mvcmodels/mapping_editor_table_model.py
@@ -57,8 +57,6 @@ from spinedb_api.export_mapping.export_mapping import (
     IndexNameMapping,
     DefaultValueIndexNameMapping,
     ParameterDefaultValueTypeMapping,
-    RelationshipClassObjectHighlightingMapping,
-    RelationshipObjectHighlightingMapping,
 )
 from spinetoolbox.helpers import color_from_index
 from ..commands import SetMappingNullable, SetMappingPositions, SetMappingProperty
@@ -463,9 +461,7 @@ _names = {
     ParameterValueTypeMapping: "Value types",
     RelationshipClassMapping: "Relationship classes",
     RelationshipClassObjectClassMapping: "Object classes",
-    RelationshipClassObjectHighlightingMapping: "Relationship classes",
     RelationshipMapping: "Relationships",
-    RelationshipObjectHighlightingMapping: "Relationships",
     RelationshipObjectMapping: "Objects",
     ScenarioActiveFlagMapping: "Active flags",
     ScenarioAlternativeMapping: "Alternatives",

--- a/spine_items/exporter/mvcmodels/mappings_table_model.py
+++ b/spine_items/exporter/mvcmodels/mappings_table_model.py
@@ -17,7 +17,7 @@ from spinedb_api.export_mapping.export_mapping import (
     ParameterDefaultValueIndexMapping,
     ParameterValueIndexMapping,
     RelationshipClassObjectClassMapping,
-    RelationshipClassObjectHighlightingMapping,
+    RelationshipClassMapping,
 )
 from spinetoolbox.helpers import unique_name
 
@@ -131,7 +131,7 @@ class MappingsTableModel(QAbstractTableModel):
                 return spec.group_fn
             if role == self.HIGHLIGHT_DIMENSION_ROLE:
                 highlighting_mapping = next(
-                    (m for m in spec.root.flatten() if isinstance(m, RelationshipClassObjectHighlightingMapping)), None
+                    (m for m in spec.root.flatten() if isinstance(m, RelationshipClassMapping)), None
                 )
                 if highlighting_mapping is None:
                     return None
@@ -241,7 +241,7 @@ class MappingsTableModel(QAbstractTableModel):
                 self.dataChanged.emit(index, index, [self.GROUP_FN_ROLE])
             elif role == self.HIGHLIGHT_DIMENSION_ROLE:
                 highlighting_mapping = next(
-                    (m for m in spec.root.flatten() if isinstance(m, RelationshipClassObjectHighlightingMapping)), None
+                    (m for m in spec.root.flatten() if isinstance(m, RelationshipClassMapping)), None
                 )
                 if highlighting_mapping is None:
                     return False


### PR DESCRIPTION
Relationship object highlighting mappings have changed in `spinedb_api` and this PR brings `spine_items` up-to-date.

See spine-tools/Spine-Database-API#246

Fixes spine-tools/Spine-Database-API#244

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
