### PR TITLE
Fix program filepath tooltips in Tool Spec Editor

### DIFF
--- a/spine_items/tool/widgets/tool_specification_editor_window.py
+++ b/spine_items/tool/widgets/tool_specification_editor_window.py
@@ -341,6 +341,8 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
             item.setData(file_path, Qt.ItemDataRole.UserRole)
             root_item.appendRow(item)
             QTimer.singleShot(0, self._push_change_main_program_file_command)
+            tool_tip = f'<p>{self._current_main_program_file()}</p>'
+            self.programfiles_model.setData(root_item.child(0).index(), tool_tip, role=Qt.ItemDataRole.ToolTipRole)
 
     def populate_programfile_list(self, names):
         """Adds additional program files into the program files model.
@@ -372,6 +374,9 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
             if not item.rowCount():
                 index = self.programfiles_model.indexFromItem(item)
                 file_path = self._programfile_path_from_index(index)
+                if file_path:
+                    tool_tip = f'<p>{file_path}</p>'
+                    self.programfiles_model.setData(index, tool_tip, role=Qt.ItemDataRole.ToolTipRole)
                 if file_path in visible:
                     self._ui.treeView_programfiles.expand(index.parent())
                 self._programfile_set_dirty_slots[file_path] = index


### PR DESCRIPTION
In the tool specification editor the main program file and every additional program file now shows the whole file path in tooltips.

Fixes spine-tools/Spine-Toolbox#1745

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
