### PR TITLE
importer mappings button improvement

### DIFF
--- a/spine_items/importer/mvcmodels/mappings_model.py
+++ b/spine_items/importer/mvcmodels/mappings_model.py
@@ -138,6 +138,9 @@ class MappingsModel(QAbstractItemModel):
         self._add_table_row_font = QFont()
         self._add_table_row_font.setItalic(True)
 
+    def __len__(self):
+        return len(self._mappings)
+
     def real_table_names(self):
         """Returns real table names.
 

--- a/spine_items/importer/widgets/import_mappings.py
+++ b/spine_items/importer/widgets/import_mappings.py
@@ -61,9 +61,9 @@ class ImportMappings:
         self._mappings_model.modelReset.connect(self._dummify_root_indexes)
         self._mappings_model.dataChanged.connect(self._select_changed_mapping)
         self._mappings_model.rowsInserted.connect(self._update_current_after_mapping_insertion)
-        self._mappings_model.rowsInserted.connect(self._update_mapping_list_button_enabled_state_when_adding)
+        self._mappings_model.rowsInserted.connect(self._set_mapping_list_buttons_enabled)
         self._mappings_model.rowsRemoved.connect(self._show_list_after_mapping_removal)
-        self._mappings_model.rowsRemoved.connect(self._update_mapping_list_button_enabled_state_when_removing)
+        self._mappings_model.rowsRemoved.connect(self._set_mapping_list_buttons_enabled)
         self._ui.source_list.selectionModel().currentChanged.connect(self._change_list)
         self._ui.mapping_list.selectionModel().currentChanged.connect(self._change_flattened_mappings)
         self._ui.new_button.clicked.connect(self._new_mapping)
@@ -92,11 +92,9 @@ class ImportMappings:
             self._ui.mapping_list.selectionModel().setCurrentIndex(
                 self._mappings_model.index(0, 0, current), QItemSelectionModel.ClearAndSelect
             )
-            buttons_enabled = True
         else:
             self._ui.mapping_list.selectionModel().setCurrentIndex(QModelIndex(), QItemSelectionModel.ClearAndSelect)
-            buttons_enabled = False
-        self._set_mapping_list_buttons_enabled(buttons_enabled, current)
+        self._set_mapping_list_buttons_enabled(current)
 
     @Slot(QModelIndex, int, int)
     def _update_current_after_mapping_insertion(self, table_index, first, last):
@@ -131,25 +129,8 @@ class ImportMappings:
         if table_index != self._ui.mapping_list.rootIndex():
             self._ui.source_list.selectionModel().setCurrentIndex(table_index, QItemSelectionModel.ClearAndSelect)
 
-    @Slot(QModelIndex, int, int)
-    def _update_mapping_list_button_enabled_state_when_adding(self, table_index):
-        """Enables the Remove and Duplicate buttons after adding a mapping into an empty mappings list.
-
-        Args:
-            table_index (QModelIndex): table index
-        """
-        self._set_mapping_list_buttons_enabled(True, table_index)
-
-    @Slot(QModelIndex, int, int)
-    def _update_mapping_list_button_enabled_state_when_removing(self, table_index):
-        """Disables the Remove and Duplicate buttons after removing all mappings from a mappings list.
-
-        Args:
-            table_index (QModelIndex): table index
-        """
-        self._set_mapping_list_buttons_enabled(self._mappings_model.rowCount(table_index) != 0, table_index)
-
-    def _set_mapping_list_buttons_enabled(self, enabled, table_index):
+    @Slot(QModelIndex)
+    def _set_mapping_list_buttons_enabled(self, table_index):
         """Sets New, Duplicate and Remove button enabled state when selecting a source table.
 
         Args:

--- a/spine_items/importer/widgets/import_mappings.py
+++ b/spine_items/importer/widgets/import_mappings.py
@@ -156,9 +156,12 @@ class ImportMappings:
             enabled (bool): enabled state
             table_index (QModelIndex): table index
         """
-        self._ui.new_button.setEnabled(table_index.row() != 0)
-        self._ui.remove_button.setEnabled(enabled)
-        self._ui.duplicate_button.setEnabled(enabled)
+        is_first_or_last = table_index.row() in [0, len(self._ui.mapping_list.model()) - 1]
+        self._ui.new_button.setEnabled(not is_first_or_last)
+
+        has_entries = self._mappings_model.rowCount(table_index) > 0
+        self._ui.remove_button.setEnabled(has_entries)
+        self._ui.duplicate_button.setEnabled(has_entries)
 
     @Slot(QModelIndex, QModelIndex)
     def _change_flattened_mappings(self, current, previous):


### PR DESCRIPTION
Further improves implementation related to spine-tools/Spine-Toolbox#2046:

This also disables the 'add' button when selecting the 'rename this to add' entry. As part of that rewrite, a bunch of code could be removed again.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
