### PR TITLE
Black formatting

### DIFF
--- a/spine_items/exporter/widgets/preview_updater.py
+++ b/spine_items/exporter/widgets/preview_updater.py
@@ -323,11 +323,14 @@ class PreviewUpdater:
             bottom_right (QModelIndex): bottom right corner of modified mappings' in mapping list model
             roles (list of int): changed data's role
         """
-        if not {
-            MappingsTableModel.ALWAYS_EXPORT_HEADER_ROLE,
-            MappingsTableModel.FIXED_TABLE_NAME_ROLE,
-            MappingsTableModel.GROUP_FN_ROLE,
-        } & set(roles):
+        if (
+            not {
+                MappingsTableModel.ALWAYS_EXPORT_HEADER_ROLE,
+                MappingsTableModel.FIXED_TABLE_NAME_ROLE,
+                MappingsTableModel.GROUP_FN_ROLE,
+            }
+            & set(roles)
+        ):
             return
         row = self._mappings_proxy_model.mapToSource(self._ui.mappings_table.currentIndex()).row()
         index = self._mappings_table_model.index(row, 0)


### PR DESCRIPTION
We had to downgrade Black due to dependency conflicts.

Re spine-tools/Spine-Toolbox#2115

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
