### PR TITLE
Fix Cannot exit from specification editor without naming

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
--e git+https://github.com/spine-tools/Spine-Toolbox.git@2123_tool_spec_editor_exit_no_save#egg=spinetoolbox
+-e git+https://github.com/spine-tools/Spine-Toolbox.git#egg=spinetoolbox
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
--e git+https://github.com/spine-tools/Spine-Toolbox.git#egg=spinetoolbox
+-e git+https://github.com/spine-tools/Spine-Toolbox.git@2123_tool_spec_editor_exit_no_save#egg=spinetoolbox
 -e .

--- a/spine_items/data_transformer/widgets/specification_editor_window.py
+++ b/spine_items/data_transformer/widgets/specification_editor_window.py
@@ -87,7 +87,7 @@ class SpecificationEditorWindow(SpecificationEditorWindowBase):
 
         return Ui_MainWindow()
 
-    def _make_new_specification(self, spec_name):
+    def _make_new_specification(self, spec_name, exiting=None):
         """See base class."""
         description = self._spec_toolbar.description()
         filter_name = self._ui.filter_combo_box.currentText()

--- a/spine_items/exporter/widgets/specification_editor_window.py
+++ b/spine_items/exporter/widgets/specification_editor_window.py
@@ -291,7 +291,7 @@ class SpecificationEditorWindow(SpecificationEditorWindowBase):
         qApp.processEvents()  # pylint: disable=undefined-variable
         self.resize(size)
 
-    def _make_new_specification(self, spec_name):
+    def _make_new_specification(self, spec_name, exiting=None):
         """See base class."""
         description = self._spec_toolbar.description()
         mapping_specification = deepcopy(self._new_spec.mapping_specifications())

--- a/spine_items/importer/widgets/import_editor_window.py
+++ b/spine_items/importer/widgets/import_editor_window.py
@@ -122,10 +122,11 @@ class ImportEditorWindow(SpecificationEditorWindowBase):
     def settings_group(self):
         return "mappingPreviewWindow"
 
-    def _save(self):
+    def _save(self, exiting=None):
         """See base class."""
-        if super()._save():
+        if super()._save(exiting):
             self._import_mappings.specification_saved()
+            return True
 
     @property
     def _duplicate_kwargs(self):
@@ -165,7 +166,7 @@ class ImportEditorWindow(SpecificationEditorWindowBase):
         qApp.processEvents()  # pylint: disable=undefined-variable
         self.resize(size)
 
-    def _make_new_specification(self, spec_name):
+    def _make_new_specification(self, spec_name, exiting=None):
         mappings_dict = self._mappings_model.store()
         mappings_dict.update(self._import_sources.store_connectors())
         description = self._spec_toolbar.description()

--- a/spine_items/tool/widgets/tool_specification_editor_window.py
+++ b/spine_items/tool/widgets/tool_specification_editor_window.py
@@ -190,18 +190,24 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
         if opt_widget:
             opt_widget.init_widget(specification)
 
-    def _make_new_specification(self, spec_name):
+    def _make_new_specification(self, spec_name, exiting=None):
         """See base class."""
         # Check that tool type is selected
         if self._ui.comboBox_tooltype.currentIndex() == -1:
-            self.show_error("Tool spec type not selected")
-            return None
+            if exiting:
+                return None
+            else:
+                self.show_error("Tool spec type not selected")
+                return None
         toolspectype = self._ui.comboBox_tooltype.currentText().lower()
         # Check that Tool Spec has a main program file except for Executable Tool Specs
         main_program_file = self._current_main_program_file()
         if main_program_file is None and toolspectype != "executable":
-            self.show_error("Please add a main program file")
-            return None
+            if exiting:
+                return None
+            else:
+                self.show_error("Please add a main program file")
+                return None
         new_spec_dict = {"name": spec_name, "description": self._spec_toolbar.description(), "tooltype": toolspectype}
         main_prgm_dir, main_prgm_file_name = os.path.split(main_program_file) if main_program_file else ("", "")
         if not main_prgm_dir:
@@ -245,9 +251,9 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
         d["execution_settings"] = opt_widget.add_execution_settings()
         return d
 
-    def _save(self):
+    def _save(self, exiting=None):
         """Saves spec. If successful, also saves all modified program files."""
-        if not super()._save():
+        if not super()._save(exiting):
             return False
         saved = []
         for file_path, doc in self._programfile_documents.items():


### PR DESCRIPTION
When trying to exit an items specification editor without naming the specification, users are now asked if they want to exit without saving or cancel the exit. For the Tool item the same applies when tool type or main program file is not selected.

Fixes spine-tools/Spine-Toolbox#2123

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
