### PR TITLE
Fix select new file in Tool Spec Editor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
+e-e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
--e git+https://github.com/spine-tools/Spine-Toolbox.git#egg=spinetoolbox
+-e git+https://github.com/spine-tools/Spine-Toolbox.git@issue_2099_tool_spec_select_new_file#egg=spinetoolbox
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-e-e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
+-e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
 -e git+https://github.com/spine-tools/Spine-Toolbox.git@issue_2099_tool_spec_select_new_file#egg=spinetoolbox
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
--e git+https://github.com/spine-tools/Spine-Toolbox.git@issue_2099_tool_spec_select_new_file#egg=spinetoolbox
+-e git+https://github.com/spine-tools/Spine-Toolbox.git#egg=spinetoolbox
 -e .


### PR DESCRIPTION
If the spec editor of a tool that has no specification is opened, the text editor widget is completely empty and the header is changed into "No file selected". When a main program file is created, it is automatically selected and the text editor is ready for use. +fixed a bug that sometimes when creating a new main program file, the file would be created, but it would not appear in the spec editor.

Re spine-tools/Spine-Toolbox#2099

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
