### PR TITLE
Don't reload kernels if they have already been loaded

### DIFF
--- a/spine_items/tool/widgets/tool_spec_optional_widgets.py
+++ b/spine_items/tool/widgets/tool_spec_optional_widgets.py
@@ -233,6 +233,7 @@ class PythonToolSpecOptionalWidget(OptionalWidget):
     @Slot()
     def _restore_selected_kernel(self):
         """Sets the previously selected kernel spec as the current item after the model has been refreshed."""
+        self._kernel_spec_model_initialized = True
         if self._selected_kernel is not None:
             row = self.find_index_by_data(self._selected_kernel)
             if row == -1:
@@ -245,6 +246,7 @@ class PythonToolSpecOptionalWidget(OptionalWidget):
     def _restore_saved_kernel(self):
         """Sets index of the kernel spec combobox to show the item that was saved with the Tool Specification.
         Make sure this is called after kernel spec model has been populated."""
+        self._kernel_spec_model_initialized = True
         if not self._saved_kernel:
             self.ui.comboBox_kernel_specs.setCurrentIndex(0)  # Set 'Select kernel spec...'
         else:

--- a/tests/tool/widgets/test_PythonToolSpecOptionalWidget.py
+++ b/tests/tool/widgets/test_PythonToolSpecOptionalWidget.py
@@ -16,10 +16,12 @@ Unit tests for PythonToolSpecOptionalWidget class.
 
 import unittest
 from unittest import mock
+from unittest.mock import MagicMock
 import logging
 import sys
 from PySide6.QtWidgets import QApplication, QWidget
 from spine_items.tool.widgets.tool_spec_optional_widgets import PythonToolSpecOptionalWidget
+from spine_items.tool.tool_specifications import PythonTool
 
 
 class TestPythonToolSpecOptionalWidget(unittest.TestCase):
@@ -37,12 +39,18 @@ class TestPythonToolSpecOptionalWidget(unittest.TestCase):
             datefmt="%Y-%m-%d %H:%M:%S",
         )
 
-    def test_constructor(self):
+    def test_constructor_and_init(self):
         with mock.patch(
             "spine_items.tool.widgets.tool_spec_optional_widgets.PythonToolSpecOptionalWidget._toolbox"
         ) as mock_toolbox:
             mock_toolbox.qsettings.return_value = MockQSettings()
+            mock_logger = MagicMock()
+            python_tool_spec = PythonTool("a", "python", "", ["fake_main_program.py"], MockQSettings(), mock_logger)
+            python_tool_spec.set_execution_settings()  # Sets defaults
+            python_tool_spec.execution_settings["executable"] = "fake_python.exe"
             opt_widget = PythonToolSpecOptionalWidget(mock_toolbox)
+            opt_widget.init_widget(python_tool_spec)
+            self.assertEqual("fake_python.exe", opt_widget.get_executable())
         self.assertIsInstance(opt_widget, PythonToolSpecOptionalWidget)
 
 


### PR DESCRIPTION
Stops reloading kernels when switching between the Basic Console and Jupyter Console radio buttons in Tool Specification Editor.

Re spine-tools/Spine-Toolbox#1809

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [x] Unit tests pass
