### PR TITLE
Fix Text and icons overlapping in tool spec editor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
--e git+https://github.com/spine-tools/Spine-Toolbox.git#egg=spinetoolbox
+-e git+https://github.com/spine-tools/Spine-Toolbox.git@issue_2160_text_and_icons_overlapping#egg=spinetoolbox
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git#egg=spine_engine
--e git+https://github.com/spine-tools/Spine-Toolbox.git@issue_2160_text_and_icons_overlapping#egg=spinetoolbox
+-e git+https://github.com/spine-tools/Spine-Toolbox.git#egg=spinetoolbox
 -e .

--- a/spine_items/tool/widgets/tool_specification_editor_window.py
+++ b/spine_items/tool/widgets/tool_specification_editor_window.py
@@ -287,7 +287,7 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
     def init_programfile_list(self):
         """List program files in QTreeView."""
         for name in ("Main program file", "Additional program files"):
-            item = QStandardItem(name)
+            item = QStandardItem(name + "        ")
             item.setFlags(item.flags() & ~Qt.ItemIsEditable & ~Qt.ItemIsSelectable)
             self.programfiles_model.appendRow(item)
         # Setup 'Main' item
@@ -415,24 +415,24 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
 
     def init_io_file_list(self):
         for name in ("Input files", "Optional input files", "Output files"):
-            item = QStandardItem(name)
+            item = QStandardItem(name + "         ")
             item.setFlags(item.flags() & ~Qt.ItemIsEditable & ~Qt.ItemIsSelectable)
             self.io_files_model.appendRow(item)
         # Setup 'Input' item
         index = self.io_files_model.index(0, 0)
-        widget = ToolBarWidget("Input files", self)
+        widget = ToolBarWidget("Input files", self, True)
         widget.tool_bar.addActions([self._ui.actionAdd_input_files, self._ui.actionRemove_selected_input_files])
         widget.tool_bar.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self._ui.treeView_io_files.setIndexWidget(index, widget)
         # Setup 'Optional' item
         index = self.io_files_model.index(1, 0)
-        widget = ToolBarWidget("Optional input files", self)
+        widget = ToolBarWidget("Optional input files", self, True)
         widget.tool_bar.addActions([self._ui.actionAdd_opt_input_files, self._ui.actionRemove_selected_opt_input_files])
         widget.tool_bar.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self._ui.treeView_io_files.setIndexWidget(index, widget)
         # Setup 'Output' item
         index = self.io_files_model.index(2, 0)
-        widget = ToolBarWidget("Output files", self)
+        widget = ToolBarWidget("Output files", self, True)
         widget.tool_bar.addActions([self._ui.actionAdd_output_files, self._ui.actionRemove_selected_output_files])
         widget.tool_bar.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self._ui.treeView_io_files.setIndexWidget(index, widget)


### PR DESCRIPTION
The icons in Program files and Input & output files -widgets don't overlap with the texts anymore.

Fixes spine-tools/Spine-Toolbox#2160

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
