### PR TITLE
fix importer pivot forces ignored column data type to float

### DIFF
--- a/spine_items/importer/mvcmodels/mappings_model.py
+++ b/spine_items/importer/mvcmodels/mappings_model.py
@@ -1167,7 +1167,9 @@ class MappingsModel(QAbstractItemModel):
         if not flattened_mappings.root_mapping.is_pivoted():
             self._recommend_float_type(component)
             return
-        excluded_columns = flattened_mappings.root_mapping.non_pivoted_columns()
+        not_pivoted_columns = set(flattened_mappings.root_mapping.non_pivoted_columns())
+        ignored_columns = set(flattened_mappings.skip_columns())
+        excluded_columns = sorted(list(not_pivoted_columns | ignored_columns))
         self.multi_column_type_recommended.emit(excluded_columns, FloatConvertSpec())
 
     def _recommend_string_type(self, component):


### PR DESCRIPTION
It used to be that only columns that were not pivoted didn't have their data types changed to floats. Now also ignored columns from Mapping options are excluded from the conversion.

Fixes spine-tools/Spine-Toolbox#2158

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
