### PR TITLE
upgrade pyside to fix Windows 11 crash

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 packages = find:
 zip_safe = False
 install_requires =
-    pyside6 >= 6.4.0, !=6.4.2, < 6.5.0
+    pyside6 >= 6.5.0
     pyodbc >=4.0
     sqlalchemy >=1.3, <1.4  # v1.4 does not pass tests
     pygments >=2.8


### PR DESCRIPTION
Matches spine-tools/Spine-Toolbox#2194

Fixes spine-tools/Spine-Toolbox#2161 and spine-tools/Spine-Toolbox#2121

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
