### PR TITLE
Add tooltip warning about long scenario names in db editor

### DIFF
--- a/spine_items/utils.py
+++ b/spine_items/utils.py
@@ -152,7 +152,7 @@ def generate_filter_subdirectory_name(resources, filter_id_hash):
     if subdirectory:
         scenario_name = _single_scenario_name_or_none(resources)
         if scenario_name is not None:
-            subdirectory = scenario_name[:15] + "_" + subdirectory
+            subdirectory = scenario_name[:20] + "_" + subdirectory
     return subdirectory
 
 


### PR DESCRIPTION
Increased the amount of scenario names' characters in generated subdirectories from 15 to 20.

Re spine-tools/Spine-Toolbox#2081

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
