### PR TITLE
Speed up checking Tools' notifications

### DIFF
--- a/spine_items/tool/tool.py
+++ b/spine_items/tool/tool.py
@@ -97,6 +97,9 @@ class Tool(DBWriterItemBase):
         self._log_process_output = log_process_output
         self._resources_from_upstream = list()
         self._resources_from_downstream = list()
+        self._available_resources = list()
+        self._req_file_paths = set()
+        self._input_files_not_found = None
 
     def set_up(self):
         execute_in_work = self.execute_in_work
@@ -447,17 +450,32 @@ class Tool(DBWriterItemBase):
             self.add_notification(
                 f"Tool specification <b>{n}</b> path does not exist. Fix this in Tool specification editor."
             )
-        duplicates = self._input_file_model.duplicate_paths()
-        if duplicates:
-            self.add_notification("Duplicate input files:<br>{}".format("<br>".join(duplicates)))
-        file_paths = self._find_input_files(self._resources_from_upstream + self._resources_from_downstream)
-        file_paths = flatten_file_path_duplicates(file_paths, self._logger)
-        not_found = [k for k, v in file_paths.items() if v is None]
-        if not_found:
+        resources = self._resources_from_upstream + self._resources_from_downstream
+        resources_changed = resources != self._available_resources
+        req_files_changed = False
+        if self.specification():
+            required_files = self.specification().inputfiles
+            req_files_changed = required_files != self._req_file_paths
+            # No need to perform slow check for if all the file requirements are/aren't still satisfied
+            # if no changes have been made to the Tool's requirements or available resources
+            if required_files and (req_files_changed or resources_changed):
+                file_paths = self._find_input_files(resources)
+                file_paths = flatten_file_path_duplicates(file_paths, self._logger)
+                self._input_files_not_found = [k for k, v in file_paths.items() if v is None]
+        if self._input_files_not_found:
             self.add_notification(
                 "File(s) {0} needed to execute this Tool are not provided by any input item. "
-                "Connect items that provide the required files to this Tool.".format(", ".join(not_found))
+                "Connect items that provide the required files to this Tool.".format(", ".join(self._input_files_not_found))
             )
+        if resources_changed or req_files_changed:
+            # Only check for duplicate files in available resources when the resources have changed
+            if resources_changed:
+                self._available_resources = resources
+                duplicates = self._input_file_model.duplicate_paths()
+                if duplicates:
+                    self.add_notification("Duplicate input files:<br>{}".format("<br>".join(duplicates)))
+            if req_files_changed:
+                self._req_file_paths = required_files
         missing_args = ", ".join(arg.arg for arg in self.cmd_line_args if isinstance(arg, LabelArg) and arg.missing)
         if missing_args:
             self.add_notification(

--- a/spine_items/tool/tool.py
+++ b/spine_items/tool/tool.py
@@ -465,7 +465,9 @@ class Tool(DBWriterItemBase):
         if self._input_files_not_found:
             self.add_notification(
                 "File(s) {0} needed to execute this Tool are not provided by any input item. "
-                "Connect items that provide the required files to this Tool.".format(", ".join(self._input_files_not_found))
+                "Connect items that provide the required files to this Tool.".format(
+                    ", ".join(self._input_files_not_found)
+                )
             )
         if resources_changed or req_files_changed:
             # Only check for duplicate files in available resources when the resources have changed

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -50,34 +50,6 @@ class TestCheckableFileListModel(unittest.TestCase):
         self.assertEqual(index.data(), str(Path.cwd() / "path" / "to" / "pack_file"))
         self.assertEqual(index.data(Qt.ItemDataRole.ToolTipRole), str(Path.cwd() / "path" / "to" / "pack_file"))
 
-    def test_duplicate_files(self):
-        dupe1 = file_resource("item name", str(Path.cwd() / "path" / "to" / "other" / "file" / "A1"), "file label")
-        dupe2 = file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "pack_file"))
-        single_resources = [
-            dupe1,
-            dupe1,
-            file_resource("item name", str(Path.cwd() / "path" / "to" / "file" / "A1"), "file label"),
-            file_resource("item name", str(Path.cwd() / "path" / "to" / "file" / "Worcestershire"), "file label"),
-            file_resource("item name", str(Path.cwd() / "path" / "to" / "file" / "Sriracha"), "file label"),
-            file_resource("some name", str(Path.cwd() / "path" / "to" / "other" / "file" / "B12"), "file label"),
-            file_resource("item name", str(Path.cwd() / "path" / "to" / "other" / "file" / "Sriracha"), "some label"),
-        ]
-        pack_resources = [
-            file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "other" / "pack_file")),
-            file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "some" / "pack_file")),
-            file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "pack_file2")),
-            dupe2,
-            file_resource_in_pack("some name", "pack label", str(Path.cwd() / "path" / "to" / "pack_file21")),
-            file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "pack_file3")),
-            dupe2
-        ]
-        self._model.update(single_resources + pack_resources)
-        results = self._model.duplicate_paths()
-        expected = set()
-        expected.add(str(dupe1.path))
-        expected.add(str(dupe2.path))
-        self.assertEqual(results, expected)
-
     def test_replace_single_resource(self):
         single_resource = file_resource("item name", str(Path.cwd() / "path" / "to" / "file"), "file label")
         self._model.update([single_resource])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -50,6 +50,34 @@ class TestCheckableFileListModel(unittest.TestCase):
         self.assertEqual(index.data(), str(Path.cwd() / "path" / "to" / "pack_file"))
         self.assertEqual(index.data(Qt.ItemDataRole.ToolTipRole), str(Path.cwd() / "path" / "to" / "pack_file"))
 
+    def test_duplicate_files(self):
+        dupe1 = file_resource("item name", str(Path.cwd() / "path" / "to" / "other" / "file" / "A1"), "file label")
+        dupe2 = file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "pack_file"))
+        single_resources = [
+            dupe1,
+            dupe1,
+            file_resource("item name", str(Path.cwd() / "path" / "to" / "file" / "A1"), "file label"),
+            file_resource("item name", str(Path.cwd() / "path" / "to" / "file" / "Worcestershire"), "file label"),
+            file_resource("item name", str(Path.cwd() / "path" / "to" / "file" / "Sriracha"), "file label"),
+            file_resource("some name", str(Path.cwd() / "path" / "to" / "other" / "file" / "B12"), "file label"),
+            file_resource("item name", str(Path.cwd() / "path" / "to" / "other" / "file" / "Sriracha"), "some label"),
+        ]
+        pack_resources = [
+            file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "other" / "pack_file")),
+            file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "some" / "pack_file")),
+            file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "pack_file2")),
+            dupe2,
+            file_resource_in_pack("some name", "pack label", str(Path.cwd() / "path" / "to" / "pack_file21")),
+            file_resource_in_pack("item name", "pack label", str(Path.cwd() / "path" / "to" / "pack_file3")),
+            dupe2
+        ]
+        self._model.update(single_resources + pack_resources)
+        results = self._model.duplicate_paths()
+        expected = set()
+        expected.add(str(dupe1.path))
+        expected.add(str(dupe2.path))
+        self.assertEqual(results, expected)
+
     def test_replace_single_resource(self):
         single_resource = file_resource("item name", str(Path.cwd() / "path" / "to" / "file"), "file label")
         self._model.update([single_resource])

--- a/tests/tool/test_Tool.py
+++ b/tests/tool/test_Tool.py
@@ -183,7 +183,6 @@ class TestTool(unittest.TestCase):
         separator = os.sep
         item_dict = {"type": "Tool", "description": "", "x": 0, "y": 0, "specification": "simple_exec"}
         tool = self._add_tool(item_dict)
-        # print(self._temp_dir.name)
         url1 = os.path.join(self._temp_dir.name, "more_files", "input1.csv")
         url2 = os.path.join(self._temp_dir.name, "more_files", "data.csv")
         url3 = os.path.join(self._temp_dir.name, "more filess", "input1.csv")

--- a/tests/tool/test_Tool.py
+++ b/tests/tool/test_Tool.py
@@ -180,14 +180,20 @@ class TestTool(unittest.TestCase):
     def test_find_input_files(self):
         """Test that input files are correctly found in resources
         when required input files and available resources are updated"""
+        separator = os.sep
         item_dict = {"type": "Tool", "description": "", "x": 0, "y": 0, "specification": "simple_exec"}
         tool = self._add_tool(item_dict)
+        # print(self._temp_dir.name)
         url1 = os.path.join(self._temp_dir.name, "more_files", "input1.csv")
         url2 = os.path.join(self._temp_dir.name, "more_files", "data.csv")
         url3 = os.path.join(self._temp_dir.name, "more filess", "input1.csv")
         url4 = os.path.join(self._temp_dir.name, "other.csv")
         url5 = os.path.join(self._temp_dir.name, "other", "input2.csv")
         url6 = os.path.join(self._temp_dir.name, "input3.csv")
+        expected_urls = {"url1": url1, "url2": url2, "url3": url3, "url4": url4, "url5": url5, "url6": url6}
+        for key, url in expected_urls.items():
+            i = url.find(separator)
+            expected_urls[key] = url[:i] + separator + url[i:]
         resources = [
             ProjectItemResource("Exporter", "file", "first", url="file:///" + url1, metadata={}, filterable=False),
             ProjectItemResource("Exporter", "url", "second", url="file:///" + url2, metadata={}, filterable=False),
@@ -195,22 +201,21 @@ class TestTool(unittest.TestCase):
             ProjectItemResource("Exporter", "url", "fourth", url="file:///" + url4, metadata={}, filterable=False)
         ]
         result = tool._find_input_files(resources)
-        expected = {'input2.csv': None, 'input1.csv': [url1, url3]}
+        expected = {'input1.csv': [expected_urls["url1"], expected_urls["url3"]], 'input2.csv': None}
         self.assertEqual(expected, result)
         resources.pop(0)
         resources.append(ProjectItemResource(
             "Exporter", "file", "fifth", url="file:///" + url5, metadata={}, filterable=False)
         )
         result = tool._find_input_files(resources)
-        print(result)
-        expected = {'input2.csv': [url5], 'input1.csv': [url3]}
+        expected = {'input2.csv': [expected_urls["url5"]], 'input1.csv': [expected_urls["url3"]]}
         self.assertEqual(expected, result)
         resources.append(ProjectItemResource(
             "Exporter", "file", "sixth", url="file:///" + url6, metadata={}, filterable=False)
         )
         tool.specification().inputfiles = set(["input2.csv", os.path.join(self._temp_dir.name, "input3.csv")])
         result = tool._find_input_files(resources)
-        expected = {os.path.join(self._temp_dir.name, "input3.csv"): [url6], 'input2.csv': [url5]}
+        expected = {os.path.join(self._temp_dir.name, "input3.csv"): [expected_urls["url6"]], 'input2.csv': [expected_urls["url5"]]}
         self.assertEqual(expected, result)
 
     def _add_tool(self, item_dict=None):


### PR DESCRIPTION
On large projects that have a large amount of files as possible resources for a Tool, checking the Tool's notifications took a long time. Now the checks for duplicate files in resource files and checking if the input file requirements are met are only conducted when either the requirements or resources have changed. The checking of file duplicates has also been made faster.

Re spine-tools/Spine-Toolbox#2083

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
