### PR TITLE
Further speedup Tool's notification check

### DIFF
--- a/spine_items/tool/tool.py
+++ b/spine_items/tool/tool.py
@@ -436,7 +436,7 @@ class Tool(DBWriterItemBase):
             if not filename:
                 # It's a directory
                 continue
-            file_paths[req_file_path] = find_file(filename, resources)
+            file_paths[req_file_path] = find_file(filename, resources, one_file=True)
         return file_paths
 
     def _check_notifications(self):

--- a/spine_items/tool/utils.py
+++ b/spine_items/tool/utils.py
@@ -58,13 +58,14 @@ def file_paths_from_resources(resources):
     return file_paths
 
 
-def find_file(filename, resources):
+def find_file(filename, resources, one_file=None):
     """
     Returns all occurrences of full paths to given file name in resources available.
 
     Args:
         filename (str): Searched file name (no path)
         resources (list): list of resources available from upstream items
+        one_file (bool): If True, a list containing only the first found matching file is returned
 
     Returns:
         list: Full paths to file if found, None if not found
@@ -75,6 +76,8 @@ def find_file(filename, resources):
         _, file_candidate = os.path.split(file_path)
         if os.path.normcase(file_candidate) == filename:
             found_file_paths.append(file_path)
+            if one_file:
+                break
     return found_file_paths if found_file_paths else None
 
 

--- a/tests/tool/test_Tool.py
+++ b/tests/tool/test_Tool.py
@@ -200,8 +200,10 @@ class TestTool(unittest.TestCase):
             ProjectItemResource("Exporter", "url", "fourth", url="file:///" + url4, metadata={}, filterable=False)
         ]
         result = tool._find_input_files(resources)
-        expected = {'input1.csv': [expected_urls["url1"], expected_urls["url3"]], 'input2.csv': None}
-        self.assertEqual(expected, result)
+        expected = {"input1.csv": [expected_urls["url1"], expected_urls["url3"]], "input2.csv": None}
+        self.assertEqual(2, len(result))
+        self.assertEqual(expected["input2.csv"], result["input2.csv"])
+        self.assertTrue(expected_urls["url3"] in result["input1.csv"] or expected_urls["url1"] in result["input1.csv"])
         resources.pop(0)
         resources.append(ProjectItemResource(
             "Exporter", "file", "fifth", url="file:///" + url5, metadata={}, filterable=False)


### PR DESCRIPTION
If a ProjectItemResource has a filepath, instead of it being formed every time it is needed, it is now calculated only once. The check for fulfilling required files is now completed once one match is found for every required file.

Re spine-tools/Spine-Toolbox#2083

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
