### PR TITLE
Fix Exporter running indefinitely when outputting to directory on OneDrive

### DIFF
--- a/spine_items/exporter/do_work.py
+++ b/spine_items/exporter/do_work.py
@@ -148,7 +148,7 @@ def _export_to_file(
         header_always = (m.always_export_header for m in specifications)
         group_fns = (m.group_fn for m in specifications)
         write(database_map, writer, *mappings, empty_data_header=header_always, group_fns=group_fns)
-    except (PermissionError, WriterException) as e:
+    except (FileNotFoundError, PermissionError, WriterException) as e:
         logger.msg_error.emit(str(e))
         if cancel_on_error:
             return False


### PR DESCRIPTION
Sometimes Exporter's `do_work()` fails to create the output directory when the project is stored on OneDrive. This manifests as a Traceback from `FileNotFoundError` which we now catch properly in a `except` block preventing the crash.

Fixes spine-tools/Spine-Toolbox#2211

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
