### PR TITLE
Fix Exporter mappings not disabling

### DIFF
--- a/spine_items/exporter/commands.py
+++ b/spine_items/exporter/commands.py
@@ -154,7 +154,7 @@ class SetMappingEnabled(QUndoCommand):
         name = self._mappings_table_model.index(row, 0).data()
         self._row = row
         self._previously_enabled = (
-            self._mappings_table_model.index(self._row, 0).data(Qt.ItemDataRole.CheckStateRole)
+            self._mappings_table_model.index(self._row, 0).data(Qt.ItemDataRole.CheckStateRole).value
             == Qt.CheckState.Checked.value
         )
         super().__init__(("disable" if self._previously_enabled else "enable") + f" '{name}'")


### PR DESCRIPTION
Due to some pyside changes disabling a mapping from an Exporter specification editor was impossible, the checkbox was always checked.

Fixes spine-tools/Spine-Toolbox#2236

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
