### PR TITLE
Fix items after a rename in Toolbox

### DIFF
--- a/spine_items/tool/widgets/options_widgets.py
+++ b/spine_items/tool/widgets/options_widgets.py
@@ -44,7 +44,7 @@ class OptionsWidget(QWidget):
 
     @property
     def _settings(self):
-        return self._project._settings
+        return self._project.app_settings
 
     @property
     def _logger(self):

--- a/spine_items/tool/widgets/tool_spec_optional_widgets.py
+++ b/spine_items/tool/widgets/tool_spec_optional_widgets.py
@@ -24,8 +24,7 @@ from spinetoolbox.kernel_fetcher import KernelFetcher
 
 class OptionalWidget(QWidget):
     def __init__(self, parent):
-        """Init class.
-
+        """
         Args:
             parent (ToolSpecificationEditorWindow): Tool spec editor window
         """
@@ -36,18 +35,6 @@ class OptionalWidget(QWidget):
     def _toolbox(self):
         return self._parent._toolbox
 
-    @property
-    def _project(self):
-        return self._toolbox._project
-
-    @property
-    def _settings(self):
-        return self._project._settings
-
-    @property
-    def _logger(self):
-        return self._toolbox._logger
-
     def init_widget(self, specification):
         raise NotImplementedError
 
@@ -57,8 +44,7 @@ class OptionalWidget(QWidget):
 
 class PythonToolSpecOptionalWidget(OptionalWidget):
     def __init__(self, parent):
-        """Init class.
-
+        """
         Args:
             parent (ToolSpecificationEditorWindow): Tool spec editor window
         """
@@ -263,7 +249,10 @@ class PythonToolSpecOptionalWidget(OptionalWidget):
 
 class ExecutableToolSpecOptionalWidget(OptionalWidget):
     def __init__(self, parent):
-        """Init class."""
+        """
+        Args:
+            parent (QWidget): parent widget
+        """
         from ..ui.executable_cmd_exec_options import Ui_Form  # pylint: disable=import-outside-toplevel
 
         super().__init__(parent)


### PR DESCRIPTION
`SpineToolboxProject.settings` was renamed to `SpineToolboxProject.app_settings`. This fixes items broken by the change.

Re spine-tools/Spine-Toolbox#2237

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
