### PR TITLE
Fix fully collapsable widgets

### DIFF
--- a/spine_items/data_transformer/ui/class_renamer_editor.py
+++ b/spine_items/data_transformer/ui/class_renamer_editor.py
@@ -47,6 +47,7 @@ class Ui_Form(object):
         self.splitter = QSplitter(Form)
         self.splitter.setObjectName(u"splitter")
         self.splitter.setOrientation(Qt.Horizontal)
+        self.splitter.setChildrenCollapsible(False)
         self.available_classes_tree_widget = ClassTreeWidget(self.splitter)
         __qtreewidgetitem = QTreeWidgetItem()
         __qtreewidgetitem.setText(0, u"1");

--- a/spine_items/data_transformer/ui/class_renamer_editor.ui
+++ b/spine_items/data_transformer/ui/class_renamer_editor.ui
@@ -31,6 +31,9 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
      <widget class="ClassTreeWidget" name="available_classes_tree_widget">
       <property name="dragEnabled">
        <bool>true</bool>

--- a/spine_items/data_transformer/ui/parameter_renamer_editor.py
+++ b/spine_items/data_transformer/ui/parameter_renamer_editor.py
@@ -45,7 +45,8 @@ class Ui_Form(object):
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
         self.splitter = QSplitter(Form)
         self.splitter.setObjectName(u"splitter")
-        self.splitter.setOrientation(Qt.Orientation.Horizontal)
+        self.splitter.setOrientation(Qt.Horizontal)
+        self.splitter.setChildrenCollapsible(False)
         self.available_parameters_tree_view = ParameterTreeWidget(self.splitter)
         __qtreewidgetitem = QTreeWidgetItem()
         __qtreewidgetitem.setText(0, u"1");

--- a/spine_items/data_transformer/ui/parameter_renamer_editor.ui
+++ b/spine_items/data_transformer/ui/parameter_renamer_editor.ui
@@ -31,6 +31,9 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
      <widget class="ParameterTreeWidget" name="available_parameters_tree_view">
       <property name="dragEnabled">
        <bool>true</bool>

--- a/spine_items/data_transformer/ui/value_transformer_editor.py
+++ b/spine_items/data_transformer/ui/value_transformer_editor.py
@@ -49,7 +49,8 @@ class Ui_Form(object):
         self.horizontalLayout.setObjectName(u"horizontalLayout")
         self.splitter = QSplitter(Form)
         self.splitter.setObjectName(u"splitter")
-        self.splitter.setOrientation(Qt.Orientation.Horizontal)
+        self.splitter.setOrientation(Qt.Horizontal)
+        self.splitter.setChildrenCollapsible(False)
         self.available_parameters_tree_view = ParameterTreeWidget(self.splitter)
         __qtreewidgetitem = QTreeWidgetItem()
         __qtreewidgetitem.setText(0, u"1");

--- a/spine_items/data_transformer/ui/value_transformer_editor.ui
+++ b/spine_items/data_transformer/ui/value_transformer_editor.ui
@@ -31,6 +31,9 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
      <widget class="ParameterTreeWidget" name="available_parameters_tree_view">
       <property name="dragEnabled">
        <bool>true</bool>

--- a/spine_items/tool/ui/tool_properties.py
+++ b/spine_items/tool/ui/tool_properties.py
@@ -86,6 +86,7 @@ class Ui_Form(object):
         self.splitter = QSplitter(Form)
         self.splitter.setObjectName(u"splitter")
         self.splitter.setOrientation(Qt.Vertical)
+        self.splitter.setChildrenCollapsible(False)
         self.treeView_cmdline_args = ArgsTreeView(self.splitter)
         self.treeView_cmdline_args.setObjectName(u"treeView_cmdline_args")
         sizePolicy2 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)

--- a/spine_items/tool/ui/tool_properties.ui
+++ b/spine_items/tool/ui/tool_properties.ui
@@ -87,6 +87,9 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
      <widget class="ArgsTreeView" name="treeView_cmdline_args">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">


### PR DESCRIPTION
Disabled fully collapsing widgets by setting every QSplitters childrenCollapsible property to false.

Fixes spine-tools/Spine-Toolbox#2167

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
