### PR TITLE
Fix Toolbox crashing when clicking Exporter spinbox arrows

### DIFF
--- a/spine_items/exporter/widgets/specification_editor_window.py
+++ b/spine_items/exporter/widgets/specification_editor_window.py
@@ -799,7 +799,6 @@ class SpecificationEditorWindow(SpecificationEditorWindowBase):
         )
         self._ui.always_export_header_check_box.stateChanged.connect(self._change_always_export_header)
 
-    @Slot(int)
     def _change_parameter_dimensions(self, dimensions):
         """
         Pushes a command to undo stack.
@@ -984,7 +983,6 @@ class SpecificationEditorWindow(SpecificationEditorWindowBase):
             self._ui.group_fn_combo_box.setCurrentText(group_fn_display_name)
             self._ui.group_fn_combo_box.currentTextChanged.connect(self._change_root_mapping_group_fn)
 
-    @Slot(int)
     def _change_highlight_dimension(self, dimension):
         """Pushes a command to change highlight dimension to undo stack.
 
@@ -1007,7 +1005,6 @@ class SpecificationEditorWindow(SpecificationEditorWindowBase):
         self._ui.highlight_dimension_spin_box.setValue(highlight_dimension + 1)
         self._ui.highlight_dimension_spin_box.valueChanged.connect(self._change_highlight_dimension)
 
-    @Slot(int)
     def _change_relationship_dimensions(self, dimensions):
         """
         Pushes a command to undo stack.


### PR DESCRIPTION
Spinbox arrows in exporter spec editor no longer crash toolbox

Fixes spine-tools/Spine-Toolbox#2235

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
