### PR TITLE
Fix GitHub actions after version bump and tagging

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -37,8 +37,9 @@ jobs:
         PYTHONUTF8: 1
       run: |
         python -m pip install --upgrade pip
-        pip install wheel
-        pip install -r requirements.txt
+        python -m pip install wheel
+        python -m pip install --no-deps -e .
+        python -m pip install -r requirements.txt
     - name: List packages
       run:
         pip list


### PR DESCRIPTION
`spinetoolbox` package gets installed along other `spine_items` requirements when we run GitHub actions. Installation of `spinetoolbox`, however, requires that the latest version of `spine_items` is available on PyPI. There is a corner case when the version does not exist: right before we publish new versions to PyPI. This prevents GitHub actions from succeeding.

Instead of allowing `spinetoolbox` to install another "shadow" `spine_items` package in `site-packages`, we now install the `spine-items` repository as editable package with `pip` (without installing its dependencies at this point) before we actually install `requirements.txt`. Since, at this point, `pip` finds `spine_items` already installed, it happily installs `spinetoolbox` as well.

## Checklist before merging
- [ ] Unit tests pass
