### PR TITLE
Fix Importer's available resources checked states

### DIFF
--- a/spine_items/importer/importer.py
+++ b/spine_items/importer/importer.py
@@ -252,7 +252,8 @@ class Importer(DBWriterItemBase):
         self._toolbox.undo_stack.push(ChangeItemSelectionCommand(self.name, self._file_model, index, checked))
 
     def upstream_resources_updated(self, resources):
-        self._file_model.update(resources)
+        if resources:
+            self._file_model.update(resources)
         self._check_notifications()
 
     def replace_resources_from_upstream(self, old, new):


### PR DESCRIPTION
When both Tool and a Data Connection are connected to an Importer, the connection from Tool -> Importer, clears the Importer's available resources list. This is why Importer's available resource checked states we're not loaded correctly from project.json when opening a project.

Fixes spine-tools/Spine-Toolbox#2315

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
