### PR TITLE
Fix importer fewer columns than expected Traceback

### DIFF
--- a/spine_items/importer/mvcmodels/mappings_model.py
+++ b/spine_items/importer/mvcmodels/mappings_model.py
@@ -1121,6 +1121,20 @@ class MappingsModel(QAbstractItemModel):
         index = self.index(row, FlattenedColumn.REGEXP, list_index)
         self.dataChanged.emit(index, index, [Qt.ItemDataRole.DisplayRole])
 
+    def check_validity_of_columns(self, list_index, header):
+        """Checks that the mapping doesn't have column refs
+        that are larger than the source table column count
+
+        Args:
+            list_index (QModelIndex): index to mappings list
+            header (Iterable): source table header
+        Returns:
+            bool: True if no source ref. is out of range, False otherwise
+        """
+        mapping_list_item = list_index.internalPointer()
+        table_name = mapping_list_item.source_table_item.name
+        return mapping_list_item.flattened_mappings.root_mapping.check_for_invalid_column_refs(header, table_name)
+
     @staticmethod
     def polish_mapping(list_index, header):
         """Polishes flattened mappings.


### PR DESCRIPTION
Now when an importer spec is modified to have a column reference that is out of range for the source data, an error is shown. If such importer spec is executed an error will also be thrown and logged.

Fixes spine-tools/Spine-Toolbox#2333

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
