### PR TITLE
Fix previously unsupported database dialects in Data connection

### DIFF
--- a/spine_items/utils.py
+++ b/spine_items/utils.py
@@ -54,7 +54,9 @@ def convert_to_sqlalchemy_url(urllib_url, item_name="", logger=None):
                 url["database"] = os.path.abspath(database)
             sa_url = URL("sqlite", **url)  # pylint: disable=unexpected-keyword-arg
         else:
-            db_api = spinedb_api.SUPPORTED_DIALECTS[dialect]
+            db_api = spinedb_api.SUPPORTED_DIALECTS.get(dialect)
+            if db_api is None:
+                db_api = spinedb_api.helpers.UNSUPPORTED_DIALECTS[dialect]
             drivername = f"{dialect}+{db_api}"
             sa_url = URL(drivername, **url)  # pylint: disable=unexpected-keyword-arg
     except Exception as e:  # pylint: disable=broad-except


### PR DESCRIPTION
Some database dialects that are not supported by spinedb_api but are supported by SqlAlchemy did not work at all as Data connection URLs. This PR alleviates the situation.

Re spine-tools/Spine-Toolbox#2329

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
