### PR TITLE
Issue 2371 database validation URL

### DIFF
--- a/spine_items/database_validation.py
+++ b/spine_items/database_validation.py
@@ -44,7 +44,13 @@ class _ValidationTask(QRunnable):
         try:
             self._signals.moveToThread(QThread.currentThread())
             if self._dialect == "sqlite":
-                database_path = Path(self._sa_url.database)
+                if type(self._sa_url) != str:
+                    database_path = Path(self._sa_url.database)
+                else:
+                    if not self._sa_url.startswith("sqlite:///"):
+                        self._signals.validation_failed.emit("Given URL is invalid for selected dialect sqlite.")
+                        return
+                    database_path = Path(self._sa_url[10:])
                 if not database_path.exists():
                     self._signals.validation_failed.emit("File does not exist. Check the Database field in the URL.")
                     return

--- a/tests/test_database_validation.py
+++ b/tests/test_database_validation.py
@@ -42,6 +42,21 @@ class TestDatabaseConnectionValidator(unittest.TestCase):
                 validator.deleteLater()
             self.assertTrue(listener.is_success)
 
+    def test_successful_validation_of_sqlite_database_with_str_url(self):
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + str(Path(temp_dir, "db.sqlite"))
+            create_new_spine_database(url)
+            listener = _Listener()
+            validator = DatabaseConnectionValidator()
+            try:
+                validator.validate_url("sqlite", url, listener.failure, listener.success)
+                while not listener.is_done:
+                    QApplication.processEvents()
+            finally:
+                validator.wait_for_finish()
+                validator.deleteLater()
+            self.assertTrue(listener.is_success)
+
     def test_validation_failure_due_to_missing_sqlite_file(self):
         with TemporaryDirectory() as temp_dir:
             url = "sqlite:///" + str(Path(temp_dir, "db.sqlite"))
@@ -57,6 +72,21 @@ class TestDatabaseConnectionValidator(unittest.TestCase):
                 validator.deleteLater()
             self.assertFalse(listener.is_success)
             self.assertEqual(listener.fail_message, "File does not exist. Check the Database field in the URL.")
+
+    def test_validation_failure_due_to_incorrect_str_url(self):
+        with TemporaryDirectory() as temp_dir:
+            url = str(Path(temp_dir, "db.sqlite"))
+            listener = _Listener()
+            validator = DatabaseConnectionValidator()
+            try:
+                validator.validate_url("sqlite", url, listener.failure, listener.success)
+                while not listener.is_done:
+                    QApplication.processEvents()
+            finally:
+                validator.wait_for_finish()
+                validator.deleteLater()
+            self.assertFalse(listener.is_success)
+            self.assertEqual(listener.fail_message, "Given URL is invalid for selected dialect sqlite.")
 
 
 class _Listener:


### PR DESCRIPTION
Data connection should no longer cause Tracebacks if the user tries to enter an invalid sqlite URL.

Fixes spine-tools/Spine-Toolbox#2371

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
