### PR TITLE
Adapt ToolInstances to ExecutionManager changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git@0.8-dev#egg=spinedb_api
--e git+https://github.com/spine-tools/spine-engine.git@0.8-dev#egg=spine_engine
+-e git+https://github.com/spine-tools/spine-engine.git@execution_mngr_update#egg=spine_engine
 -e git+https://github.com/spine-tools/Spine-Toolbox.git@0.8-dev#egg=spinetoolbox
 -e .[dev]

--- a/spine_items/tool/tool_instance.py
+++ b/spine_items/tool/tool_instance.py
@@ -188,6 +188,8 @@ class JuliaToolInstance(ToolInstance):
         """Returns a '--sysimage=path/to/sysimage' arg for the Julia
         process or None if the sysimage path is missing or invalid."""
         sysimage_path = self._owner.options.get("julia_sysimage", "")
+        if sysimage_path == "":
+            return None
         if sysimage_path != "" and not os.path.isfile(sysimage_path):
             self._logger.msg_error.emit(f"Ignoring Sysimage <b>{sysimage_path}</b> because it does not exist")
             return None

--- a/spine_items/tool/tool_specifications.py
+++ b/spine_items/tool/tool_specifications.py
@@ -115,7 +115,7 @@ class ToolSpecification(ProjectItemSpecification):
             inputfiles (list): List of required data files
             inputfiles_opt (list, optional): List of optional data files (wildcards may be used)
             outputfiles (list, optional): List of output files (wildcards may be used)
-            cmdline_args (str, optional): Tool command line arguments (read from tool definition file)
+            cmdline_args (list, optional): Tool Specification command line arguments
         """
         super().__init__(name, description, item_type=ItemInfo.item_type(), item_category=ItemInfo.item_category())
         self._settings = settings
@@ -258,7 +258,7 @@ class GAMSTool(ToolSpecification):
             inputfiles (list): List of required data files
             inputfiles_opt (list, optional): List of optional data files (wildcards may be used)
             outputfiles (list, optional): List of output files (wildcards may be used)
-            cmdline_args (str, optional): GAMS tool command line arguments (read from tool definition file)
+            cmdline_args (list, optional): GAMS Tool Specification command line arguments
         """
         super().__init__(
             name,
@@ -402,7 +402,7 @@ class JuliaTool(ToolSpecification):
             inputfiles (list): List of required data files
             inputfiles_opt (list, optional): List of optional data files (wildcards may be used)
             outputfiles (list, optional): List of output files (wildcards may be used)
-            cmdline_args (str, optional): Julia tool command line arguments (read from tool definition file)
+            cmdline_args (list, optional): Julia Tool Specification command line arguments
             execution_settings (dict, optional): Julia tool spec execution settings
         """
         super().__init__(
@@ -506,7 +506,7 @@ class PythonTool(ToolSpecification):
             inputfiles (list): List of required data files
             inputfiles_opt (list, optional): List of optional data files (wildcards may be used)
             outputfiles (list, optional): List of output files (wildcards may be used)
-            cmdline_args (str, optional): Python tool command line arguments (read from tool definition file)
+            cmdline_args (list, optional): Python Tool Specification command line arguments
             execution_settings (dict, optional): Python tool spec execution settings
         """
         super().__init__(
@@ -610,7 +610,7 @@ class ExecutableTool(ToolSpecification):
             inputfiles (list): List of required data files
             inputfiles_opt (list, optional): List of optional data files (wildcards may be used)
             outputfiles (list, optional): List of output files (wildcards may be used)
-            cmdline_args (str, optional): Tool command line arguments (read from tool definition file)
+            cmdline_args (list, optional): Executable Tool Specification command line arguments
             execution_settings (dict): Settings for executing a (shell) command instead of a file
             definition_file_path (str): Absolute path to spec definition file. Only used when running a (shell) command
                 in 'source' execution mode

--- a/spine_items/tool/utils.py
+++ b/spine_items/tool/utils.py
@@ -29,20 +29,20 @@ def get_julia_path_and_project(exec_settings):
         exec_settings (dict): Execution settings
 
     Returns:
-        list of str: e.g. ["path/to/julia", "--project=path/to/project/"]
+        list of str: e.g. ["path/to/julia", "--project=path/to/project/"] or None if kernel does not exist.
     """
     use_jupyter_console = exec_settings["use_jupyter_console"]
     if use_jupyter_console:
         kernel_name = exec_settings["kernel_spec_name"]
         resource_dir = find_kernel_specs().get(kernel_name)
         if resource_dir is None:
-            return [None]
+            return None
         filepath = os.path.join(resource_dir, "kernel.json")
         with open(filepath, "r") as fh:
             try:
                 kernel_spec = json.load(fh)
             except json.decoder.JSONDecodeError:
-                return [None]
+                return None
         julia = kernel_spec["argv"].pop(0)
         project_arg = next((arg for arg in kernel_spec["argv"] if arg.startswith("--project=")), None)
         project = "" if project_arg is None else project_arg.split("--project=")[1]


### PR DESCRIPTION
This PR cleans up ToolInstance classes and adapts ExecutionManager instantiations to changes on spine-engine's PR https://github.com/spine-tools/spine-engine/pull/118.

Re spine-tools/spine-engine#117

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
