### PR TITLE
Data connection marks invalid db refs red

### DIFF
--- a/spine_items/data_connection/widgets/custom_menus.py
+++ b/spine_items/data_connection/widgets/custom_menus.py
@@ -37,7 +37,7 @@ class DcRefContextMenu(CustomContextMenu):
         self.add_action("Remove reference(s)", enabled=dc.any_refs_selected)
         self.add_action("Copy file reference(s) to project", enabled=dc.file_refs_selected)
         self.addSeparator()
-        self.add_action("Refresh reference(s)", enabled=dc.file_refs_selected)
+        self.add_action("Refresh reference(s)", enabled=dc.any_refs_selected)
 
 
 class DcDataContextMenu(CustomContextMenu):

--- a/spine_items/data_store/data_store.py
+++ b/spine_items/data_store/data_store.py
@@ -356,21 +356,21 @@ class DataStore(ProjectItem):
             self._url["dialect"], sa_url, self._set_invalid_url_notification, self._accept_url
         )
 
-    @Slot(str)
-    def _set_invalid_url_notification(self, error_message):
+    @Slot(str, str)
+    def _set_invalid_url_notification(self, error_message, url):
         """Sets a single notification that warns about broken URL.
 
         Args:
             error_message (str): URL failure message
         """
         self.clear_notifications()
-        self.add_notification(f"Couldn't connect to the database: {error_message}")
+        self.add_notification(f"Couldn't connect to the database <b>{url}</b>: {error_message}")
         if self._resource_to_replace is None:
             self._resources_to_predecessors_changed()
             self._resources_to_successors_changed()
 
-    @Slot()
-    def _accept_url(self):
+    @Slot(str)
+    def _accept_url(self, url):
         """Sets URL as validated and updates advertised resources."""
         self._url_validated = True
         self.clear_notifications()

--- a/spine_items/database_validation.py
+++ b/spine_items/database_validation.py
@@ -48,22 +48,27 @@ class _ValidationTask(QRunnable):
                     database_path = Path(self._sa_url.database)
                 else:
                     if not self._sa_url.startswith("sqlite:///"):
-                        self._signals.validation_failed.emit("Given URL is invalid for selected dialect sqlite.")
+                        self._signals.validation_failed.emit(
+                            "Given URL is invalid for selected dialect sqlite.", self._sa_url
+                        )
                         return
                     database_path = Path(self._sa_url[10:])
                 if not database_path.exists():
-                    self._signals.validation_failed.emit("File does not exist. Check the Database field in the URL.")
+                    self._signals.validation_failed.emit(
+                        "File does not exist. Check the Database field in the URL.", str(database_path)
+                    )
                     return
                 elif database_path.is_dir():
                     self._signals.validation_failed.emit(
-                        "Database points to a directory, not a file." " Check the Database field in the URL."
+                        "Database points to a directory, not a file." " Check the Database field in the URL.",
+                        str(database_path),
                     )
                     return
             error = check_database_url(self._sa_url)
             if error is not None:
-                self._signals.validation_failed.emit(error)
+                self._signals.validation_failed.emit(error, self._sa_url)
                 return
-            self._signals.validation_succeeded.emit()
+            self._signals.validation_succeeded.emit(self._sa_url)
         finally:
             self._signals.finished.emit()
             application = QApplication.instance()
@@ -74,8 +79,8 @@ class _ValidationTask(QRunnable):
 class _TaskSignals(QObject):
     """Signals for validation task."""
 
-    validation_failed = Signal(str)
-    validation_succeeded = Signal()
+    validation_failed = Signal(str, str)
+    validation_succeeded = Signal(str)
     finished = Signal()
 
 


### PR DESCRIPTION
Now when a db connection is not valid the reference is colored to red just as the file references are to
indicate that there is a problem. By refreshing the connection can be checked again.

Fixes spine-tools/Spine-Toolbox#2375

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
