### PR TITLE
Fix issues with remote (non-Spine) databases

### DIFF
--- a/spine_items/data_connection/data_connection.py
+++ b/spine_items/data_connection/data_connection.py
@@ -213,18 +213,18 @@ class DataConnection(ProjectItem):
 
     @Slot(bool)
     def show_add_db_reference_dialog(self, _=False):
-        """Opens a dialog where user can select a url to be added as reference for this Data Connection."""
+        """Opens a dialog where user can select an url to be added as reference for this Data Connection."""
         selector = UrlSelectorDialog(self._toolbox.qsettings(), self._toolbox, self._toolbox)
         selector.exec()
-        url = selector.url
-        if not url:  # Cancel button clicked
+        full_url = selector.url
+        if not full_url:  # Cancel button clicked
             return
-        url, credentials = split_url_credentials(url)
+        url, credentials = split_url_credentials(full_url)
         if url in self.db_references:
             self._logger.msg_warning.emit(f"Reference to database <b>{url}</b> already exists")
             return
         self._database_validator.validate_url(
-            selector.dialect, url, self._log_database_reference_error, success_slot=None
+            selector.dialect, full_url, self._log_database_reference_error, success_slot=None
         )
         self.db_credentials[url] = credentials
         self._toolbox.undo_stack.push(AddDCReferencesCommand(self, [], [url]))

--- a/spine_items/database_validation.py
+++ b/spine_items/database_validation.py
@@ -10,6 +10,7 @@
 ######################################################################################################################
 """Utilities to validate that a database exists."""
 from pathlib import Path
+from sqlalchemy.engine.url import make_url
 
 from PySide6.QtCore import QObject, QRunnable, QThread, QThreadPool, QTimer, Signal, Slot
 from PySide6.QtWidgets import QApplication
@@ -31,7 +32,7 @@ class _ValidationTask(QRunnable):
         """
         super().__init__()
         self._dialect = dialect
-        self._sa_url = sa_url
+        self._sa_url = make_url(sa_url)
         self._signals = _TaskSignals()
         self._signals.moveToThread(None)
         self._signals.validation_failed.connect(fail_slot)
@@ -58,6 +59,8 @@ class _ValidationTask(QRunnable):
                 self._signals.validation_failed.emit(error)
                 return
             self._signals.validation_succeeded.emit()
+        except Exception as error:
+            self._signals.validation_failed.emit(str(error))
         finally:
             self._signals.finished.emit()
             application = QApplication.instance()

--- a/spine_items/importer/importer.py
+++ b/spine_items/importer/importer.py
@@ -214,21 +214,25 @@ class Importer(DBWriterItemBase):
         self.open_import_editor(index)
 
     def open_import_editor(self, index):
-        """Opens Import editor for the given index."""
-        filepath = None
+        """Opens Import editor for the given index.
+
+        Args:
+            index (QModelIndex): resource list index
+        """
+        source = None
         if index.isValid():
             resource = self._file_model.resource(index)
-            if resource.type_ == "database":
-                filepath = resource.url
+            if resource.type_ == "url":
+                source = resource.url
             else:
                 if not resource.hasfilepath:
                     self._logger.msg_error.emit("File does not exist yet.")
                 else:
                     if not os.path.exists(resource.path):
-                        self._logger.msg_error.emit(f"Cannot find file '{filepath}'.")
+                        self._logger.msg_error.emit(f"Cannot find file '{source}'.")
                     else:
-                        filepath = resource.path
-        self._toolbox.show_specification_form(self.item_type(), self.specification(), self, filepath=filepath)
+                        source = resource.path
+        self._toolbox.show_specification_form(self.item_type(), self.specification(), self, source=source)
 
     def select_connector_type(self, index):
         """Opens dialog to select connector type for the given index."""

--- a/spine_items/importer/importer_factory.py
+++ b/spine_items/importer/importer_factory.py
@@ -60,5 +60,5 @@ class ImporterFactory(ProjectItemFactory):
     @staticmethod
     def make_specification_editor(toolbox, specification=None, item=None, **kwargs):
         """See base class."""
-        filepath = kwargs.get("filepath")
-        return ImportEditorWindow(toolbox, specification, item, filepath)
+        source = kwargs.get("source")
+        return ImportEditorWindow(toolbox, specification, item, source)

--- a/spine_items/importer/widgets/import_editor_window.py
+++ b/spine_items/importer/widgets/import_editor_window.py
@@ -75,16 +75,16 @@ class ImportEditorWindow(SpecificationEditorWindowBase):
         def get_data_iterator(self, table, options, max_rows=-1):
             return iter([]), ()
 
-    def __init__(self, toolbox, specification, item=None, filepath=None):
+    def __init__(self, toolbox, specification, item=None, source=None):
         """
         Args:
             toolbox (QMainWindow): ToolboxUI class
             specification (ImporterSpecification)
-            filepath (str, optional): Importee path
+            source (str, optional): Importee file path or URL
         """
         super().__init__(toolbox, specification, item)
         self.takeCentralWidget().deleteLater()
-        self._filepath = filepath if filepath else self._FILE_LESS
+        self._filepath = source if source else self._FILE_LESS
         self._mappings_model = MappingsModel(self._undo_stack, self)
         self._mappings_model.rowsInserted.connect(self._reselect_source_table)
         self._ui.source_list.setModel(self._mappings_model)
@@ -98,8 +98,8 @@ class ImportEditorWindow(SpecificationEditorWindowBase):
         self._import_mapping_options = ImportMappingOptions(self._mappings_model, self._ui, self._undo_stack)
         self._import_sources = ImportSources(self._mappings_model, self._ui, self._undo_stack, self)
         self._ui.comboBox_source_file.addItem(self._FILE_LESS)
-        if filepath:
-            self._ui.comboBox_source_file.addItem(filepath)
+        if source:
+            self._ui.comboBox_source_file.addItem(source)
         self._ui.comboBox_source_file.setCurrentIndex(-1)
         self._ui.comboBox_source_file.currentTextChanged.connect(self.start_ui)
         self._ui.toolButton_browse_source_file.clicked.connect(self._show_open_file_dialog)
@@ -130,7 +130,7 @@ class ImportEditorWindow(SpecificationEditorWindowBase):
 
     @property
     def _duplicate_kwargs(self):
-        return dict(filepath=self._filepath)
+        return dict(source=self._filepath)
 
     def _make_ui(self):
         from ..ui.import_editor_window import Ui_MainWindow  # pylint: disable=import-outside-toplevel
@@ -184,13 +184,13 @@ class ImportEditorWindow(SpecificationEditorWindowBase):
     @Slot(bool)
     def _show_open_file_dialog(self, _=False):
         if self._connection_manager.connection.__name__ == "SqlAlchemyConnector":
-            filepath = self._get_source_url()
+            source = self._get_source_url()
         else:
-            filepath = self._get_source_file_path()
-        if not filepath:
+            source = self._get_source_file_path()
+        if not source:
             return
-        self._ui.comboBox_source_file.addItem(filepath)
-        self._ui.comboBox_source_file.setCurrentText(filepath)
+        self._ui.comboBox_source_file.addItem(source)
+        self._ui.comboBox_source_file.setCurrentText(source)
 
     def _get_source_url(self):
         selector = UrlSelectorDialog(self._toolbox.qsettigns(), self._toolbox, parent=self)

--- a/spine_items/models.py
+++ b/spine_items/models.py
@@ -177,13 +177,13 @@ class CheckableFileListModel(FileListModel):
         self.dataChanged.emit(index, index, [Qt.ItemDataRole.CheckStateRole])
 
     def index_with_file_path(self):
-        """Tries to find an item that has a valid file path.
+        """Tries to find an item that has a valid file path or URL.
 
         Returns:
-            QModelIndex: index to a item with usable file path or an invalid index if none found
+            QModelIndex: index to an item with usable file path/URL, or an invalid index if none found
         """
         for row, item in enumerate(self._single_resources):
-            if item.checked and item.resource.hasfilepath:
+            if item.checked and item.resource.url:
                 return self.index(row, 0)
         for pack_row, item in enumerate(self._pack_resources):
             if item.checked:


### PR DESCRIPTION
- Data connection's database URL validation was broken for SQLite databases and tried to connect to remote databases without credentials
- Importer did not properly recognize database URLs as valid data source when double-clicking the icon

Fixes spine-tools/Spine-Toolbox#2329

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
