### PR TITLE
Fix usage of database URLs in Data connection, Importer

### DIFF
--- a/spine_items/data_connection/executable_item.py
+++ b/spine_items/data_connection/executable_item.py
@@ -18,17 +18,18 @@ from spine_engine.project_item.executable_item_base import ExecutableItemBase
 from spine_engine.utils.serialization import deserialize_path
 from .item_info import ItemInfo
 from .output_resources import scan_for_resources
+from .utils import restore_database_references
 
 
 class ExecutableItem(ExecutableItemBase):
     """The executable parts of Data Connection."""
 
-    def __init__(self, name, file_references, db_references, db_credentials, project_dir, logger):
+    def __init__(self, name, file_references, db_references, project_dir, logger):
         """
         Args:
             name (str): item's name
             file_references (list): a list of absolute paths to connected files
-            db_references (list): a list of urls to connected dbs
+            db_references (list): a list of url dicts to connected dbs
             project_dir (str): absolute path to project directory
             logger (LoggerInterface): a logger
         """
@@ -40,7 +41,6 @@ class ExecutableItem(ExecutableItemBase):
                     data_files.append(entry.path)
         self._file_paths = file_references + data_files
         self._urls = db_references
-        self._url_credentials = db_credentials
 
     @staticmethod
     def item_type():
@@ -49,13 +49,14 @@ class ExecutableItem(ExecutableItemBase):
 
     def _output_resources_forward(self):
         """See base class."""
-        return scan_for_resources(self, self._file_paths, self._urls, self._url_credentials, self._project_dir)
+        return scan_for_resources(self, self._file_paths, self._urls, self._project_dir)
 
     @classmethod
     def from_dict(cls, item_dict, name, project_dir, app_settings, specifications, logger):
         """See base class."""
         file_references = item_dict["file_references"]
         file_references = [deserialize_path(r, project_dir) for r in file_references]
-        db_references = item_dict.get("db_references", [])
-        db_credentials = item_dict.get("db_credentials", {})
-        return cls(name, file_references, db_references, db_credentials, project_dir, logger)
+        db_references = restore_database_references(
+            item_dict.get("db_references", []), item_dict.get("db_credentials", {}), project_dir
+        )
+        return cls(name, file_references, db_references, project_dir, logger)

--- a/spine_items/data_connection/output_resources.py
+++ b/spine_items/data_connection/output_resources.py
@@ -15,18 +15,18 @@ Contains utilities to scan for Data Connection's output resources.
 from pathlib import Path
 from spine_engine.project_item.project_item_resource import file_resource, transient_file_resource, url_resource
 from spine_engine.utils.serialization import path_in_dir
-from ..utils import unsplit_url_credentials
+from spinedb_api.helpers import remove_credentials_from_url
+from ..utils import convert_to_sqlalchemy_url, unsplit_url_credentials
 
 
-def scan_for_resources(provider, file_paths, urls, url_credentials, project_dir):
+def scan_for_resources(provider, file_paths, urls, project_dir):
     """
     Creates file and URL resources based on DC's references and data.
 
     Args:
         provider (ProjectItem or ExecutableItem): resource provider item
         file_paths (list of str): file paths
-        urls (list of str): urls
-        url_credentials (dict): mapping url from urls to tuple (username, password)
+        urls (list of dict): urls
         project_dir (str): absolute path to project directory
 
     Returns:
@@ -55,8 +55,7 @@ def scan_for_resources(provider, file_paths, urls, url_credentials, project_dir)
             continue
         resources.append(resource)
     for url in urls:
-        credentials = url_credentials.get(url)
-        full_url = unsplit_url_credentials(url, credentials) if credentials is not None else url
-        resource = url_resource(provider.name, full_url, f"<{provider.name}>" + url)
+        str_url = str(convert_to_sqlalchemy_url(url))
+        resource = url_resource(provider.name, str_url, f"<{provider.name}>" + remove_credentials_from_url(str_url))
         resources.append(resource)
     return resources

--- a/spine_items/data_connection/utils.py
+++ b/spine_items/data_connection/utils.py
@@ -1,0 +1,65 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Items.
+# Spine Items is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+"""This module contains utilities for Data Connection."""
+import sys
+import urllib.parse
+from spine_engine.utils.serialization import deserialize_path
+from spine_items.utils import convert_url_to_safe_string
+
+
+def restore_database_references(references_list, credentials_dict, project_dir):
+    """Restores data from serialized database references.
+
+    Args:
+        references_list (list of dict): serialized database references
+        credentials_dict (dict): mapping from safe URL to (username, password) tuple
+        project_dir (str): path to project directory
+
+    Returns:
+        list of dict: deserialized database references
+    """
+    db_references = []
+    for reference_dict in references_list:
+        if isinstance(reference_dict, str):
+            # legacy db reference
+            url = urllib.parse.urlparse(reference_dict)
+            dialect = _dialect_from_scheme(url.scheme)
+            path = url.path
+            if dialect == "sqlite" and sys.platform == "win32":
+                # Remove extra '/' from file path on Windows.
+                path = path[1:]
+            db_reference = {
+                "dialect": dialect,
+                "host": url.hostname,
+                "port": url.port,
+                "database": path,
+            }
+        else:
+            db_reference = dict(reference_dict)
+        if db_reference["dialect"] == "sqlite":
+            db_reference["database"] = deserialize_path(db_reference["database"], project_dir)
+        db_reference["username"], db_reference["password"] = credentials_dict.get(
+            convert_url_to_safe_string(db_reference), (None, None)
+        )
+        db_references.append(db_reference)
+    return db_references
+
+
+def _dialect_from_scheme(scheme):
+    """Parses dialect from URL scheme.
+
+    Args:
+        scheme (str): URL scheme
+
+    Returns:
+        str: dialect name
+    """
+    return scheme.split("+")[0]

--- a/spine_items/data_store/data_store.py
+++ b/spine_items/data_store/data_store.py
@@ -32,7 +32,7 @@ from .executable_item import ExecutableItem
 from .item_info import ItemInfo
 from .output_resources import scan_for_resources
 from ..database_validation import DatabaseConnectionValidator
-from ..utils import database_label, convert_to_sqlalchemy_url
+from ..utils import convert_url_to_safe_string, database_label, convert_to_sqlalchemy_url
 
 
 @dataclass(frozen=True)
@@ -356,20 +356,23 @@ class DataStore(ProjectItem):
             self._url["dialect"], sa_url, self._set_invalid_url_notification, self._accept_url
         )
 
-    @Slot(str, str)
+    @Slot(str, object)
     def _set_invalid_url_notification(self, error_message, url):
         """Sets a single notification that warns about broken URL.
 
         Args:
             error_message (str): URL failure message
+            url (URL): SqlAlchemy URL
         """
         self.clear_notifications()
-        self.add_notification(f"Couldn't connect to the database <b>{url}</b>: {error_message}")
+        self.add_notification(
+            f"Couldn't connect to the database <b>{convert_url_to_safe_string(url)}</b>: {error_message}"
+        )
         if self._resource_to_replace is None:
             self._resources_to_predecessors_changed()
             self._resources_to_successors_changed()
 
-    @Slot(str)
+    @Slot(object)
     def _accept_url(self, url):
         """Sets URL as validated and updates advertised resources."""
         self._url_validated = True

--- a/spine_items/importer/importer.py
+++ b/spine_items/importer/importer.py
@@ -214,21 +214,25 @@ class Importer(DBWriterItemBase):
         self.open_import_editor(index)
 
     def open_import_editor(self, index):
-        """Opens Import editor for the given index."""
-        filepath = None
+        """Opens Import editor for the given index.
+
+        Args:
+            index (QModelIndex): resource list index
+        """
+        source = None
         if index.isValid():
             resource = self._file_model.resource(index)
-            if resource.type_ == "database":
-                filepath = resource.url
+            if resource.type_ == "url":
+                source = resource.url
             else:
                 if not resource.hasfilepath:
                     self._logger.msg_error.emit("File does not exist yet.")
                 else:
                     if not os.path.exists(resource.path):
-                        self._logger.msg_error.emit(f"Cannot find file '{filepath}'.")
+                        self._logger.msg_error.emit(f"Cannot find file '{source}'.")
                     else:
-                        filepath = resource.path
-        self._toolbox.show_specification_form(self.item_type(), self.specification(), self, filepath=filepath)
+                        source = resource.path
+        self._toolbox.show_specification_form(self.item_type(), self.specification(), self, source=source)
 
     def select_connector_type(self, index):
         """Opens dialog to select connector type for the given index."""

--- a/spine_items/importer/importer_factory.py
+++ b/spine_items/importer/importer_factory.py
@@ -60,5 +60,5 @@ class ImporterFactory(ProjectItemFactory):
     @staticmethod
     def make_specification_editor(toolbox, specification=None, item=None, **kwargs):
         """See base class."""
-        filepath = kwargs.get("filepath")
-        return ImportEditorWindow(toolbox, specification, item, filepath)
+        source = kwargs.get("source")
+        return ImportEditorWindow(toolbox, specification, item, source)

--- a/spine_items/models.py
+++ b/spine_items/models.py
@@ -177,13 +177,13 @@ class CheckableFileListModel(FileListModel):
         self.dataChanged.emit(index, index, [Qt.ItemDataRole.CheckStateRole])
 
     def index_with_file_path(self):
-        """Tries to find an item that has a valid file path.
+        """Tries to find an item that has a valid file path or URL.
 
         Returns:
-            QModelIndex: index to a item with usable file path or an invalid index if none found
+            QModelIndex: index to an item with usable file path/URL, or an invalid index if none found
         """
         for row, item in enumerate(self._single_resources):
-            if item.checked and item.resource.hasfilepath:
+            if item.checked and item.resource.url:
                 return self.index(row, 0)
         for pack_row, item in enumerate(self._pack_resources):
             if item.checked:

--- a/tests/data_connection/test_DataConnectionExecutable.py
+++ b/tests/data_connection/test_DataConnectionExecutable.py
@@ -53,7 +53,7 @@ class TestDataConnectionExecutable(unittest.TestCase):
         self.assertEqual(2, len(item._file_paths))
 
     def test_stop_execution(self):
-        executable = ExecutableItem("name", [], [], {}, self._temp_dir.name, mock.MagicMock())
+        executable = ExecutableItem("name", [], [], self._temp_dir.name, mock.MagicMock())
         with mock.patch(
             "spine_engine.project_item.executable_item_base.ExecutableItemBase.stop_execution"
         ) as mock_stop_execution:
@@ -61,7 +61,7 @@ class TestDataConnectionExecutable(unittest.TestCase):
             mock_stop_execution.assert_called_once()
 
     def test_execute(self):
-        executable = ExecutableItem("name", [], [], {}, self._temp_dir.name, mock.MagicMock())
+        executable = ExecutableItem("name", [], [], self._temp_dir.name, mock.MagicMock())
         self.assertTrue(executable.execute([], [], Lock()))
 
     def test_output_resources_backward(self):
@@ -69,7 +69,7 @@ class TestDataConnectionExecutable(unittest.TestCase):
         dc_data_dir.mkdir(parents=True)
         temp_file_path = pathlib.Path(dc_data_dir, "file.txt")
         temp_file_path.touch()
-        executable = ExecutableItem("name", ["file_reference"], [], {}, self._temp_dir.name, mock.MagicMock())
+        executable = ExecutableItem("name", ["file_reference"], [], self._temp_dir.name, mock.MagicMock())
         self.assertEqual(executable.output_resources(ExecutionDirection.BACKWARD), [])
 
     def test_output_resources_forward(self):
@@ -79,7 +79,7 @@ class TestDataConnectionExecutable(unittest.TestCase):
         dc_data_dir.mkdir(parents=True)
         temp_file_path = pathlib.Path(dc_data_dir, "data_file")
         temp_file_path.touch()
-        executable = ExecutableItem("name", [str(file_reference)], [], {}, self._temp_dir.name, mock.MagicMock())
+        executable = ExecutableItem("name", [str(file_reference)], [], self._temp_dir.name, mock.MagicMock())
         output_resources = executable.output_resources(ExecutionDirection.FORWARD)
         self.assertEqual(len(output_resources), 2)
         resource = output_resources[0]

--- a/tests/data_connection/test_output_resources.py
+++ b/tests/data_connection/test_output_resources.py
@@ -18,29 +18,32 @@ from spine_items.data_connection.output_resources import scan_for_resources
 
 
 class TestScanForResources(unittest.TestCase):
-    def test_url_reference_gets_added_as_url_resource(self):
-        data_connection = MagicMock()
-        data_connection.name = "test dc"
-        project_dir_path = PurePath(__file__).parent
-        data_connection.data_dir = str(project_dir_path / ".spinetoolbox" / "test_dc")
-        file_paths = []
-        urls = ["gopher://long.gone.url"]
-        url_credentials = {}
-        resources = scan_for_resources(data_connection, file_paths, urls, url_credentials, str(project_dir_path))
-        self.assertEqual(resources, [url_resource("test dc", "gopher://long.gone.url", "gopher://long.gone.url")])
-
     def test_credentials_do_not_show_in_url_resource_label(self):
         data_connection = MagicMock()
         data_connection.name = "test dc"
         project_dir_path = PurePath(__file__).parent
         data_connection.data_dir = str(project_dir_path / ".spinetoolbox" / "test_dc")
         file_paths = []
-        urls = ["ssh://long.gone.url"]
-        url_credentials = {"ssh://long.gone.url": ("superman", "t0p s3cr3t")}
-        resources = scan_for_resources(data_connection, file_paths, urls, url_credentials, str(project_dir_path))
+        urls = [
+            {
+                "dialect": "postgresql",
+                "host": "long.gone.url",
+                "port": 5432,
+                "database": "warehouse",
+                "username": "superman",
+                "password": "t0p s3cr3t",
+            }
+        ]
+        resources = scan_for_resources(data_connection, file_paths, urls, str(project_dir_path))
         self.assertEqual(
             resources,
-            [url_resource("test dc", "ssh://superman:t0p s3cr3t@long.gone.url", "<test dc>ssh://long.gone.url")],
+            [
+                url_resource(
+                    "test dc",
+                    "postgresql+psycopg2://superman:t0p s3cr3t@long.gone.url:5432/warehouse",
+                    "<test dc>postgresql+psycopg2://long.gone.url:5432/warehous",
+                )
+            ],
         )
 
 

--- a/tests/importer/widgets/test_import_editor_window.py
+++ b/tests/importer/widgets/test_import_editor_window.py
@@ -1,0 +1,57 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Items.
+# Spine Items is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+"""Unit tests for the ``import_editor_window`` module."""
+from tempfile import TemporaryDirectory
+import unittest
+from unittest import mock
+
+from PySide6.QtWidgets import QApplication, QDialog
+
+from spine_items.importer.widgets.import_editor_window import ImportEditorWindow
+from spinedb_api.spine_io.importers.sqlalchemy_connector import SqlAlchemyConnector
+from tests.mock_helpers import clean_up_toolbox, create_toolboxui_with_project
+
+
+class TestIsUrl(unittest.TestCase):
+    def test_url_is_url(self):
+        self.assertTrue(ImportEditorWindow._is_url("sqlite:///C:\\data\\db.sqlite"))
+        self.assertTrue(ImportEditorWindow._is_url("postgresql+psycopg://spuser:s3cr3t@server.com/db"))
+
+    def test_non_url_is_not_url(self):
+        self.assertFalse(ImportEditorWindow._is_url("C:\\path\\to\\file"))
+        self.assertFalse(ImportEditorWindow._is_url("/unix/style/path"))
+
+
+class TestImportEditorWindow(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not QApplication.instance():
+            QApplication()
+
+    def setUp(self):
+        self._temp_dir = TemporaryDirectory()
+        self._toolbox = create_toolboxui_with_project(self._temp_dir.name)
+
+    def tearDown(self):
+        clean_up_toolbox(self._toolbox)
+        self._temp_dir.cleanup()
+
+    def test_get_connector_selects_sql_alchemy_connector_when_source_is_url(self):
+        editor = ImportEditorWindow(self._toolbox, None)
+        with mock.patch("spine_items.importer.widgets.import_editor_window.QDialog.exec") as exec_dialog:
+            exec_dialog.return_value = QDialog.DialogCode.Accepted
+            connector = editor._get_connector("mysql://server.com/db")
+            exec_dialog.assert_called_once()
+        self.assertIs(connector, SqlAlchemyConnector)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_database_validation.py
+++ b/tests/test_database_validation.py
@@ -49,7 +49,8 @@ class TestDatabaseConnectionValidator(unittest.TestCase):
             listener = _Listener()
             validator = DatabaseConnectionValidator()
             try:
-                validator.validate_url("sqlite", url, listener.failure, listener.success)
+                sa_url = make_url(url)
+                validator.validate_url("sqlite", sa_url, listener.failure, listener.success)
                 while not listener.is_done:
                     QApplication.processEvents()
             finally:
@@ -72,21 +73,6 @@ class TestDatabaseConnectionValidator(unittest.TestCase):
                 validator.deleteLater()
             self.assertFalse(listener.is_success)
             self.assertEqual(listener.fail_message, "File does not exist. Check the Database field in the URL.")
-
-    def test_validation_failure_due_to_incorrect_str_url(self):
-        with TemporaryDirectory() as temp_dir:
-            url = str(Path(temp_dir, "db.sqlite"))
-            listener = _Listener()
-            validator = DatabaseConnectionValidator()
-            try:
-                validator.validate_url("sqlite", url, listener.failure, listener.success)
-                while not listener.is_done:
-                    QApplication.processEvents()
-            finally:
-                validator.wait_for_finish()
-                validator.deleteLater()
-            self.assertFalse(listener.is_success)
-            self.assertEqual(listener.fail_message, "Given URL is invalid for selected dialect sqlite.")
 
 
 class _Listener:

--- a/tests/tool/test_tool_instance.py
+++ b/tests/tool/test_tool_instance.py
@@ -99,7 +99,10 @@ class TestToolInstance(unittest.TestCase):
             mock_kem.assert_called_once()
             mock_find_kernel_specs.assert_called_once()
             self.assertEqual(mock_kem.call_args[0][1], "some_julia_kernel")
-            self.assertEqual(mock_kem.call_args[0][2], ['cd("path/");', 'empty!(ARGS); append!(ARGS, ["arg1", "arg2"]);', 'include("hello.jl")'])
+            self.assertEqual(
+                mock_kem.call_args[0][2],
+                ['cd("path/");', 'empty!(ARGS); append!(ARGS, ["arg1", "arg2"]);', 'include("hello.jl")'],
+            )
         # With tool and tool spec cmd line args
         instance = self._make_julia_tool_instance(True, ["arg3"])
         with mock.patch("spine_items.tool.tool_instance.KernelExecutionManager") as mock_kem, mock.patch(
@@ -112,7 +115,10 @@ class TestToolInstance(unittest.TestCase):
             mock_kem.assert_called_once()
             mock_find_kernel_specs.assert_called_once()
             self.assertEqual(mock_kem.call_args[0][1], "some_julia_kernel")
-            self.assertEqual(mock_kem.call_args[0][2], ['cd("path/");', 'empty!(ARGS); append!(ARGS, ["arg3", "arg1", "arg2"]);', 'include("hello.jl")'])
+            self.assertEqual(
+                mock_kem.call_args[0][2],
+                ['cd("path/");', 'empty!(ARGS); append!(ARGS, ["arg3", "arg1", "arg2"]);', 'include("hello.jl")'],
+            )
 
     def test_julia_prepare_with_basic_console(self):
         # No cmd line args
@@ -126,7 +132,9 @@ class TestToolInstance(unittest.TestCase):
             instance.prepare([])
             mock_isfile.assert_called()
             mock_manager.assert_called_once()
-            self.assertEqual(["", "--sysimage=path/to/sysimage.so"], mock_manager.call_args[0][1])  # args attribute for JuliaPersistentExecutionManger
+            self.assertEqual(
+                ["", "--sysimage=path/to/sysimage.so"], mock_manager.call_args[0][1]
+            )  # args attribute for JuliaPersistentExecutionManger
             self.assertEqual(['cd("path/");', 'include("hello.jl")'], mock_manager.call_args[0][2])  # commands
             self.assertEqual("julia hello.jl", mock_manager.call_args[0][3])  # alias
         # With tool cmd line args
@@ -140,7 +148,10 @@ class TestToolInstance(unittest.TestCase):
             mock_isfile.assert_called()
             mock_manager.assert_called_once()
             self.assertEqual([""], mock_manager.call_args[0][1])
-            self.assertEqual(['cd("path/");', 'empty!(ARGS); append!(ARGS, ["arg1", "arg2"]);', 'include("hello.jl")'], mock_manager.call_args[0][2])
+            self.assertEqual(
+                ['cd("path/");', 'empty!(ARGS); append!(ARGS, ["arg1", "arg2"]);', 'include("hello.jl")'],
+                mock_manager.call_args[0][2],
+            )
             self.assertEqual("julia hello.jl arg1 arg2", mock_manager.call_args[0][3])  # alias
         # With tool and tool spec cmd line args
         instance = self._make_julia_tool_instance(False, ["arg3"])
@@ -153,7 +164,10 @@ class TestToolInstance(unittest.TestCase):
             mock_isfile.assert_called()
             mock_manager.assert_called_once()
             self.assertEqual([""], mock_manager.call_args[0][1])
-            self.assertEqual(['cd("path/");', 'empty!(ARGS); append!(ARGS, ["arg3", "arg1", "arg2"]);', 'include("hello.jl")'], mock_manager.call_args[0][2])
+            self.assertEqual(
+                ['cd("path/");', 'empty!(ARGS); append!(ARGS, ["arg3", "arg1", "arg2"]);', 'include("hello.jl")'],
+                mock_manager.call_args[0][2],
+            )
             self.assertEqual("julia hello.jl arg3 arg1 arg2", mock_manager.call_args[0][3])  # alias
 
     def test_prepare_sysimg_maker(self):
@@ -179,7 +193,7 @@ class TestToolInstance(unittest.TestCase):
         instance = self._make_gams_tool_instance()
         path_to_gams = "path/to/gams"
         with mock.patch("spine_items.tool.tool_instance.ProcessExecutionManager") as mock_manager, mock.patch(
-                "spine_items.tool.tool_instance.resolve_gams_executable"
+            "spine_items.tool.tool_instance.resolve_gams_executable"
         ) as mock_gams_exe:
             mock_manager.return_value = True
             mock_gams_exe.return_value = path_to_gams
@@ -329,7 +343,15 @@ class TestToolInstance(unittest.TestCase):
 
     @staticmethod
     def _make_python_tool_instance(use_jupyter_console, tool_spec_args=None):
-        specification = PythonTool("specification name", "python", "", ["main.py"], MockQSettings(), mock.MagicMock(), cmdline_args=tool_spec_args)
+        specification = PythonTool(
+            "specification name",
+            "python",
+            "",
+            ["main.py"],
+            MockQSettings(),
+            mock.MagicMock(),
+            cmdline_args=tool_spec_args,
+        )
         specification.set_execution_settings()
         if use_jupyter_console:
             specification.execution_settings["use_jupyter_console"] = True
@@ -338,7 +360,15 @@ class TestToolInstance(unittest.TestCase):
 
     @staticmethod
     def _make_julia_tool_instance(use_jupyter_console, tool_spec_args=None):
-        specification = JuliaTool("specification name", "julia", "", ["hello.jl"], MockQSettings(), mock.MagicMock(), cmdline_args=tool_spec_args)
+        specification = JuliaTool(
+            "specification name",
+            "julia",
+            "",
+            ["hello.jl"],
+            MockQSettings(),
+            mock.MagicMock(),
+            cmdline_args=tool_spec_args,
+        )
         specification.set_execution_settings()
         if use_jupyter_console:
             specification.execution_settings["use_jupyter_console"] = True
@@ -348,15 +378,33 @@ class TestToolInstance(unittest.TestCase):
     @staticmethod
     def _make_gams_tool_instance(temp_dir=None, tool_spec_args=None):
         path = temp_dir if temp_dir else ""
-        specification = GAMSTool("specification name", "gams", path, ["model.gms"], MockQSettings(), mock.MagicMock(), cmdline_args=tool_spec_args)
+        specification = GAMSTool(
+            "specification name",
+            "gams",
+            path,
+            ["model.gms"],
+            MockQSettings(),
+            mock.MagicMock(),
+            cmdline_args=tool_spec_args,
+        )
         return specification.create_tool_instance("path/", False, logger=mock.MagicMock(), owner=mock.MagicMock())
 
     @staticmethod
     def _make_executable_tool_instance(shell=None, cmd=None, tool_spec_args=None):
         if cmd:
-            specification = ExecutableTool("name", "executable", "", [], MockQSettings(), mock.MagicMock(), cmdline_args=tool_spec_args)
+            specification = ExecutableTool(
+                "name", "executable", "", [], MockQSettings(), mock.MagicMock(), cmdline_args=tool_spec_args
+            )
         else:
-            specification = ExecutableTool("name", "executable", "", ["program.exe"], MockQSettings(), mock.MagicMock(), cmdline_args=tool_spec_args)
+            specification = ExecutableTool(
+                "name",
+                "executable",
+                "",
+                ["program.exe"],
+                MockQSettings(),
+                mock.MagicMock(),
+                cmdline_args=tool_spec_args,
+            )
         specification.set_execution_settings()
         if shell == "cmd.exe":
             specification.execution_settings["shell"] = "cmd.exe"

--- a/tests/tool/test_tool_specifications.py
+++ b/tests/tool/test_tool_specifications.py
@@ -114,11 +114,12 @@ class TestToolSpecification(unittest.TestCase):
                 "tooltype": "python",
                 "includes_main_path": temp_dir,
                 "includes": [main_file],
-                "definition_file_path": "path/to/specification_file.json"
+                "definition_file_path": "path/to/specification_file.json",
             }
             engine = SpineEngine(project_dir=temp_dir, specifications={"Tool": [spec_dict]}, connections=list())
             jump.set_engine(engine)
             self.assertTrue(jump.is_condition_true(23))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes a number of issues that prevented database URLs (other than SQLite) from being used as references in Data Connection and Source preview in Importer specification editor.

Fixes spine-tools/Spine-Toolbox#2329

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
