### PR TITLE
Hide credentials from Importer's source URL widget

### DIFF
--- a/spine_items/importer/ui/import_editor_window.py
+++ b/spine_items/importer/ui/import_editor_window.py
@@ -28,13 +28,13 @@ from PySide6.QtGui import (QAction, QBrush, QColor, QConicalGradient,
     QTransform)
 from PySide6.QtWidgets import (QAbstractItemView, QApplication, QCheckBox, QComboBox,
     QFrame, QGridLayout, QHBoxLayout, QHeaderView,
-    QLabel, QListView, QMainWindow, QPushButton,
-    QSizePolicy, QSpacerItem, QSpinBox, QSplitter,
-    QTableView, QToolButton, QVBoxLayout, QWidget)
+    QLabel, QLineEdit, QListView, QMainWindow,
+    QPushButton, QSizePolicy, QSpacerItem, QSpinBox,
+    QSplitter, QTableView, QToolButton, QVBoxLayout,
+    QWidget)
 
 from spine_items.importer.widgets.multi_checkable_list_view import MultiCheckableListView
 from spine_items.importer.widgets.table_view_with_button_header import TableViewWithButtonHeader
-from spinetoolbox.widgets.custom_combobox import ElidedCombobox
 from spine_items import resources_icons_rc
 
 class Ui_MainWindow(object):
@@ -58,31 +58,40 @@ class Ui_MainWindow(object):
         self.verticalLayout_6.setObjectName(u"verticalLayout_6")
         self.horizontalLayout_2 = QHBoxLayout()
         self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
-        self.file_path_label = QLabel(self.centralwidget)
-        self.file_path_label.setObjectName(u"file_path_label")
+        self.source_label = QLabel(self.centralwidget)
+        self.source_label.setObjectName(u"source_label")
 
-        self.horizontalLayout_2.addWidget(self.file_path_label)
+        self.horizontalLayout_2.addWidget(self.source_label)
 
-        self.comboBox_source_file = ElidedCombobox(self.centralwidget)
-        self.comboBox_source_file.setObjectName(u"comboBox_source_file")
-        self.comboBox_source_file.setEnabled(False)
-        sizePolicy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        sizePolicy.setHorizontalStretch(0)
-        sizePolicy.setVerticalStretch(0)
-        sizePolicy.setHeightForWidth(self.comboBox_source_file.sizePolicy().hasHeightForWidth())
-        self.comboBox_source_file.setSizePolicy(sizePolicy)
-        self.comboBox_source_file.setSizeAdjustPolicy(QComboBox.AdjustToContentsOnFirstShow)
-        self.comboBox_source_file.setMinimumContentsLength(0)
+        self.source_line_edit = QLineEdit(self.centralwidget)
+        self.source_line_edit.setObjectName(u"source_line_edit")
+        self.source_line_edit.setClearButtonEnabled(True)
 
-        self.horizontalLayout_2.addWidget(self.comboBox_source_file)
+        self.horizontalLayout_2.addWidget(self.source_line_edit)
 
-        self.toolButton_browse_source_file = QToolButton(self.centralwidget)
-        self.toolButton_browse_source_file.setObjectName(u"toolButton_browse_source_file")
+        self.browse_source_button = QToolButton(self.centralwidget)
+        self.browse_source_button.setObjectName(u"browse_source_button")
         icon = QIcon()
         icon.addFile(u":/icons/folder-open-solid.svg", QSize(), QIcon.Normal, QIcon.Off)
-        self.toolButton_browse_source_file.setIcon(icon)
+        self.browse_source_button.setIcon(icon)
 
-        self.horizontalLayout_2.addWidget(self.toolButton_browse_source_file)
+        self.horizontalLayout_2.addWidget(self.browse_source_button)
+
+        self.connector_label = QLabel(self.centralwidget)
+        self.connector_label.setObjectName(u"connector_label")
+
+        self.horizontalLayout_2.addWidget(self.connector_label)
+
+        self.connector_line_edit = QLineEdit(self.centralwidget)
+        self.connector_line_edit.setObjectName(u"connector_line_edit")
+        sizePolicy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.connector_line_edit.sizePolicy().hasHeightForWidth())
+        self.connector_line_edit.setSizePolicy(sizePolicy)
+        self.connector_line_edit.setReadOnly(True)
+
+        self.horizontalLayout_2.addWidget(self.connector_line_edit)
 
 
         self.verticalLayout_6.addLayout(self.horizontalLayout_2)
@@ -359,8 +368,13 @@ class Ui_MainWindow(object):
         self.export_mappings_action.setText(QCoreApplication.translate("MainWindow", u"Export mappings...", None))
         self.import_mappings_action.setText(QCoreApplication.translate("MainWindow", u"Import mappings...", None))
         self.actionSwitch_connector.setText(QCoreApplication.translate("MainWindow", u"Switch connector...", None))
-        self.file_path_label.setText(QCoreApplication.translate("MainWindow", u"File path:", None))
-        self.toolButton_browse_source_file.setText(QCoreApplication.translate("MainWindow", u"...", None))
+        self.source_label.setText(QCoreApplication.translate("MainWindow", u"File path:", None))
+        self.source_line_edit.setPlaceholderText(QCoreApplication.translate("MainWindow", u"Select source from the browse button...", None))
+#if QT_CONFIG(tooltip)
+        self.browse_source_button.setToolTip(QCoreApplication.translate("MainWindow", u"Browse source files or specify database URL.", None))
+#endif // QT_CONFIG(tooltip)
+        self.browse_source_button.setText(QCoreApplication.translate("MainWindow", u"...", None))
+        self.connector_label.setText(QCoreApplication.translate("MainWindow", u"Connector:", None))
         self.label.setText(QCoreApplication.translate("MainWindow", u"Surplus column data type:", None))
 #if QT_CONFIG(tooltip)
         self.default_column_type_combo_box.setToolTip(QCoreApplication.translate("MainWindow", u"Select data type for additional columns in variable-length pivoted source data.", None))

--- a/spine_items/importer/ui/import_editor_window.ui
+++ b/spine_items/importer/ui/import_editor_window.ui
@@ -33,39 +33,53 @@
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
-       <widget class="QLabel" name="file_path_label">
+       <widget class="QLabel" name="source_label">
         <property name="text">
          <string>File path:</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="ElidedCombobox" name="comboBox_source_file">
-        <property name="enabled">
-         <bool>false</bool>
+       <widget class="QLineEdit" name="source_line_edit">
+        <property name="placeholderText">
+         <string>Select source from the browse button...</string>
         </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="sizeAdjustPolicy">
-         <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
-        </property>
-        <property name="minimumContentsLength">
-         <number>0</number>
+        <property name="clearButtonEnabled">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QToolButton" name="toolButton_browse_source_file">
+       <widget class="QToolButton" name="browse_source_button">
+        <property name="toolTip">
+         <string>Browse source files or specify database URL.</string>
+        </property>
         <property name="text">
          <string>...</string>
         </property>
         <property name="icon">
          <iconset resource="../../ui/resources/resources_icons.qrc">
           <normaloff>:/icons/folder-open-solid.svg</normaloff>:/icons/folder-open-solid.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="connector_label">
+        <property name="text">
+         <string>Connector:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="connector_line_edit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -557,11 +571,6 @@
   </action>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>ElidedCombobox</class>
-   <extends>QComboBox</extends>
-   <header>spinetoolbox/widgets/custom_combobox.h</header>
-  </customwidget>
   <customwidget>
    <class>TableViewWithButtonHeader</class>
    <extends>QTableView</extends>

--- a/spine_items/importer/widgets/import_sources.py
+++ b/spine_items/importer/widgets/import_sources.py
@@ -125,6 +125,7 @@ class ImportSources(QObject):
             connector (ConnectionManager): connector
             mapping (dict)
         """
+        self._ui.source_list.selectionModel().clearCurrentIndex()
         self._connector = connector
         self._connector.connection_ready.connect(self.request_new_tables_from_connector)
         self._connector.data_ready.connect(self._update_source_data)
@@ -197,7 +198,7 @@ class ImportSources(QObject):
         Sets selected table and requests data from connector
 
         Args:
-            selected (QModelIndex): current index
+            current (QModelIndex): current index
             _previous (QModelIndex): previous index
         """
         if self._connector is None:

--- a/tests/importer/widgets/test_ImportPreview_Window.py
+++ b/tests/importer/widgets/test_ImportPreview_Window.py
@@ -8,17 +8,14 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Contains unit tests for the ImportEditorWindow class.
-
-"""
+""" Contains unit tests for the ImportEditorWindow class. """
 
 import unittest
 from unittest import mock
 from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import QApplication, QWidget
 from spine_items.importer.widgets.import_editor_window import ImportEditorWindow
+from spinedb_api.spine_io.importers.csv_reader import CSVConnector
 
 
 class TestImportEditorWindow(unittest.TestCase):
@@ -31,6 +28,7 @@ class TestImportEditorWindow(unittest.TestCase):
         spec = mock.NonCallableMagicMock()
         spec.name = "spec_name"
         spec.description = "spec_desc"
+        spec.mapping = {"source_type": CSVConnector.__name__}
         toolbox = QWidget()
         toolbox.qsettings = mock.MagicMock(return_value=QSettings(toolbox))
         toolbox.restore_and_activate = mock.MagicMock()

--- a/tests/importer/widgets/test_import_editor_window.py
+++ b/tests/importer/widgets/test_import_editor_window.py
@@ -45,11 +45,14 @@ class TestImportEditorWindow(unittest.TestCase):
         self._temp_dir.cleanup()
 
     def test_get_connector_selects_sql_alchemy_connector_when_source_is_url(self):
-        editor = ImportEditorWindow(self._toolbox, None)
         with mock.patch("spine_items.importer.widgets.import_editor_window.QDialog.exec") as exec_dialog:
             exec_dialog.return_value = QDialog.DialogCode.Accepted
+            editor = ImportEditorWindow(self._toolbox, None)
+            exec_dialog.assert_called_once()
+            exec_dialog.reset_mock()
             connector = editor._get_connector("mysql://server.com/db")
             exec_dialog.assert_called_once()
+            editor.close()
         self.assertIs(connector, SqlAlchemyConnector)
 
 


### PR DESCRIPTION
We now remove username and password from the source URL before showing it in Importer Specification editor.

Also, the source combo box has been replaced by a text field which makes more sense and simplifies code.

Resolves spine-tools/Spine-Toolbox#2429

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
