### PR TITLE
Fix Number of dimensions spin box in Importer specification editor

### DIFF
--- a/spine_items/importer/ui/import_editor_window.py
+++ b/spine_items/importer/ui/import_editor_window.py
@@ -332,7 +332,7 @@ class Ui_MainWindow(object):
 
         self.dimension_spin_box = QSpinBox(self.frame_2)
         self.dimension_spin_box.setObjectName(u"dimension_spin_box")
-        self.dimension_spin_box.setMinimum(1)
+        self.dimension_spin_box.setValue(0)
 
         self.mapping_options_contents.addWidget(self.dimension_spin_box, 5, 1, 1, 1)
 
@@ -400,6 +400,9 @@ class Ui_MainWindow(object):
         self.class_type_combo_box.setItemText(4, QCoreApplication.translate("MainWindow", u"Scenario alternative", None))
         self.class_type_combo_box.setItemText(5, QCoreApplication.translate("MainWindow", u"Parameter value list", None))
 
+#if QT_CONFIG(tooltip)
+        self.map_dimension_spin_box.setToolTip(QCoreApplication.translate("MainWindow", u"Number of dimensions when value type is Map.", None))
+#endif // QT_CONFIG(tooltip)
         self.parameter_type_combo_box.setItemText(0, QCoreApplication.translate("MainWindow", u"Value", None))
         self.parameter_type_combo_box.setItemText(1, QCoreApplication.translate("MainWindow", u"Definition", None))
         self.parameter_type_combo_box.setItemText(2, QCoreApplication.translate("MainWindow", u"None", None))
@@ -418,5 +421,8 @@ class Ui_MainWindow(object):
         self.time_series_repeat_check_box.setText(QCoreApplication.translate("MainWindow", u"Repeat time series", None))
         self.parameter_type_label.setText(QCoreApplication.translate("MainWindow", u"Parameter type:", None))
         self.dimension_label.setText(QCoreApplication.translate("MainWindow", u"Number of dimensions:", None))
+#if QT_CONFIG(tooltip)
+        self.dimension_spin_box.setToolTip(QCoreApplication.translate("MainWindow", u"Number of entity dimensions.", None))
+#endif // QT_CONFIG(tooltip)
     # retranslateUi
 

--- a/spine_items/importer/ui/import_editor_window.ui
+++ b/spine_items/importer/ui/import_editor_window.ui
@@ -425,6 +425,9 @@
               </item>
               <item row="6" column="1">
                <widget class="QSpinBox" name="map_dimension_spin_box">
+                <property name="toolTip">
+                 <string>Number of dimensions when value type is Map.</string>
+                </property>
                 <property name="minimum">
                  <number>1</number>
                 </property>
@@ -518,8 +521,11 @@
               </item>
               <item row="5" column="1">
                <widget class="QSpinBox" name="dimension_spin_box">
-                <property name="minimum">
-                 <number>1</number>
+                <property name="toolTip">
+                 <string>Number of entity dimensions.</string>
+                </property>
+                <property name="value">
+                 <number>0</number>
                 </property>
                </widget>
               </item>

--- a/tests/tool/test_ToolExecutable.py
+++ b/tests/tool/test_ToolExecutable.py
@@ -152,7 +152,7 @@ class TestToolExecutable(unittest.TestCase):
         app_settings = _MockSettings()
         logger = mock.MagicMock()
         tool_specification = PythonTool(
-            "Python tool", "Python", str(script_dir), script_files, app_settings, None, logger, outputfiles=output_files
+            "Python tool", "Python", str(script_dir), script_files, app_settings, logger, outputfiles=output_files
         )
         work_dir = pathlib.Path(self._temp_dir.name, "work")
         work_dir.mkdir()
@@ -180,9 +180,7 @@ class TestToolExecutable(unittest.TestCase):
         app_settings = _MockSettings()
         item_name = "Logs stuff"
         logger = QueueLogger(Queue(), item_name, None, [])
-        tool_specification = PythonTool(
-            "Python tool", "Python", str(script_dir), script_files, app_settings, None, logger
-        )
+        tool_specification = PythonTool("Python tool", "Python", str(script_dir), script_files, app_settings, logger)
         work_dir = pathlib.Path(self._temp_dir.name, "work")
         work_dir.mkdir()
         executable = ExecutableItem(


### PR DESCRIPTION
The lower limit in the spin box is now 0, not 1 allowing for 0-dimensional entities.

Fixes spine-tools/Spine-Toolbox#2422

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
