### PR TITLE
Fix code relying on Project dock widget

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git@0.8-dev#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git@0.8-dev#egg=spine_engine
--e git+https://github.com/spine-tools/Spine-Toolbox.git@0.8-dev#egg=spinetoolbox
+-e git+https://github.com/spine-tools/Spine-Toolbox.git@issue_2560_remove_project_widget#egg=spinetoolbox
 -e .[dev]

--- a/spine_items/data_connection/data_connection_icon.py
+++ b/spine_items/data_connection/data_connection_icon.py
@@ -89,4 +89,3 @@ class DataConnectionIcon(ProjectItemIcon):
         self._drag_over = False
         self._toolbox.ui.graphicsView.scene().clearSelection()
         self.setSelected(True)
-        self.select_item()

--- a/spine_items/data_connection/widgets/data_connection_properties_widget.py
+++ b/spine_items/data_connection/widgets/data_connection_properties_widget.py
@@ -52,8 +52,7 @@ class DataConnectionPropertiesWidget(PropertiesWidgetBase):
             pos (QPoint): Mouse position
         """
         index = self.ui.treeView_dc_references.indexAt(pos)
-        dc_index = self._toolbox.ui.treeView_project.currentIndex()
-        dc = self._toolbox.project_item_model.item(dc_index).project_item
+        dc = self._active_item
         global_pos = self.ui.treeView_dc_references.viewport().mapToGlobal(pos)
         dc_ref_context_menu = DcRefContextMenu(self, global_pos, index, dc)
         option = dc_ref_context_menu.get_action()
@@ -87,8 +86,7 @@ class DataConnectionPropertiesWidget(PropertiesWidgetBase):
             pos (QPoint): Mouse position
         """
         index = self.ui.treeView_dc_data.indexAt(pos)
-        dc_index = self._toolbox.ui.treeView_project.currentIndex()
-        dc = self._toolbox.project_item_model.item(dc_index).project_item
+        dc = self._active_item
         global_pos = self.ui.treeView_dc_data.viewport().mapToGlobal(pos)
         dc_data_context_menu = DcDataContextMenu(self, global_pos, index, dc)
         option = dc_data_context_menu.get_action()

--- a/spine_items/importer/widgets/importer_properties_widget.py
+++ b/spine_items/importer/widgets/importer_properties_widget.py
@@ -52,8 +52,7 @@ class ImporterPropertiesWidget(PropertiesWidgetBase):
             pos (QPoint): Mouse position
         """
         ind = self.ui.treeView_files.indexAt(pos)  # Index of selected item in references tree view.
-        cur_index = self._toolbox.ui.treeView_project.currentIndex()  # Get selected Importer item
-        importer = self._toolbox.project_item_model.item(cur_index).project_item
+        importer = self._active_item
         global_pos = self.ui.treeView_files.viewport().mapToGlobal(pos)
         self.files_context_menu = FilesContextMenu(self, global_pos, ind)
         option = self.files_context_menu.get_action()

--- a/tests/data_connection/test_DataConnection.py
+++ b/tests/data_connection/test_DataConnection.py
@@ -691,7 +691,7 @@ class TestDataConnectionWithProject(unittest.TestCase):
         self._data_connection.rename(expected_name, "")
         # Check name
         self.assertEqual(expected_name, self._data_connection.name)  # item name
-        self.assertEqual(expected_name, self._data_connection.get_icon().name_item.text())  # name item on Design View
+        self.assertEqual(expected_name, self._data_connection.get_icon().name())
         # Check data_dir
         self.assertEqual(expected_data_dir, self._data_connection.data_dir)  # Check data dir
         # Check that file_system_watcher has one path (new data_dir)

--- a/tests/data_store/test_dataStore.py
+++ b/tests/data_store/test_dataStore.py
@@ -317,7 +317,7 @@ class TestDataStoreWithMockToolbox(unittest.TestCase):
         self.ds.rename(expected_name, "")  # Do rename
         # Check name
         self.assertEqual(expected_name, self.ds.name)  # item name
-        self.assertEqual(expected_name, self.ds.get_icon().name_item.text())  # name item on Design View
+        self.assertEqual(expected_name, self.ds.get_icon().name())  # name item on Design View
         # Check data_dir and logs_dir
         self.assertEqual(expected_data_dir, self.ds.data_dir)  # Check data dir
         # Check that the database path in properties has been updated

--- a/tests/data_transformer/test_DataTransformer.py
+++ b/tests/data_transformer/test_DataTransformer.py
@@ -110,7 +110,7 @@ class TestDataTransformer(unittest.TestCase):
         expected_short_name = "abc"
         self.transformer.rename(expected_name, "")
         self.assertEqual(expected_name, self.transformer.name)
-        self.assertEqual(expected_name, self.transformer.get_icon().name_item.text())
+        self.assertEqual(expected_name, self.transformer.get_icon().name())
         expected_data_dir = os.path.join(self.project.items_dir, expected_short_name)
         self.assertEqual(expected_data_dir, self.transformer.data_dir)
 

--- a/tests/exporter/test_Exporter.py
+++ b/tests/exporter/test_Exporter.py
@@ -127,7 +127,7 @@ class TestExporter(unittest.TestCase):
         expected_short_name = shorten(expected_name)
         self.assertTrue(self._exporter.rename(expected_name, ""))
         self.assertEqual(expected_name, self._exporter.name)
-        self.assertEqual(expected_name, self._exporter.get_icon().name_item.text())
+        self.assertEqual(expected_name, self._exporter.get_icon().name())
         expected_data_dir = os.path.join(self._project.items_dir, expected_short_name)
         self.assertEqual(expected_data_dir, self._exporter.data_dir)
 

--- a/tests/importer/test_Importer.py
+++ b/tests/importer/test_Importer.py
@@ -139,7 +139,7 @@ class TestImporter(unittest.TestCase):
         self.importer.rename(expected_name, "")
         # Check name
         self.assertEqual(expected_name, self.importer.name)  # item name
-        self.assertEqual(expected_name, self.importer.get_icon().name_item.text())  # name item on Design View
+        self.assertEqual(expected_name, self.importer.get_icon().name())  # name item on Design View
         # Check data_dir
         expected_data_dir = os.path.join(self.project.items_dir, expected_short_name)
         self.assertEqual(expected_data_dir, self.importer.data_dir)  # Check data dir

--- a/tests/tool/test_Tool.py
+++ b/tests/tool/test_Tool.py
@@ -136,7 +136,7 @@ class TestTool(unittest.TestCase):
         tool.rename(expected_name, "")
         # Check name
         self.assertEqual(expected_name, tool.name)  # item name
-        self.assertEqual(expected_name, tool.get_icon().name_item.text())  # name item on Design View
+        self.assertEqual(expected_name, tool.get_icon().name())  # name item on Design View
         # Check data_dir
         expected_data_dir = os.path.join(self.project.items_dir, expected_short_name)
         self.assertEqual(expected_data_dir, tool.data_dir)  # Check data dir

--- a/tests/view/test_View.py
+++ b/tests/view/test_View.py
@@ -95,7 +95,7 @@ class TestView(unittest.TestCase):
         self.view.rename(expected_name, "")
         # Check name
         self.assertEqual(expected_name, self.view.name)  # item name
-        self.assertEqual(expected_name, self.view.get_icon().name_item.text())  # name item on Design View
+        self.assertEqual(expected_name, self.view.get_icon().name())  # name item on Design View
         # Check data_dir
         expected_data_dir = os.path.join(self.project.items_dir, expected_short_name)
         self.assertEqual(expected_data_dir, self.view.data_dir)  # Check data dir


### PR DESCRIPTION
This PR removes spine-items's dependency from Toolbox's Project dock widget.

Fixes spine-tools/Spine-Toolbox#2560

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
