### PR TITLE
Fix changing Importer's mapping type

### DIFF
--- a/spine_items/importer/mvcmodels/mappings_model.py
+++ b/spine_items/importer/mvcmodels/mappings_model.py
@@ -20,7 +20,7 @@ from PySide6.QtGui import QColor, QFont
 from spinetoolbox.helpers import plain_to_rich, list_to_rich_text, unique_name
 from spinedb_api.parameter_value import join_value_and_type, split_value_and_type
 from spinedb_api import from_database, ParameterValueFormatError
-from spinedb_api.import_mapping.import_mapping import ScenarioBeforeAlternativeMapping
+from spinedb_api.import_mapping.import_mapping import default_import_mapping, ScenarioBeforeAlternativeMapping
 from spinedb_api.import_mapping.import_mapping_compat import (
     parse_named_mapping_spec,
     import_mapping_from_dict,
@@ -733,7 +733,7 @@ class MappingsModel(QAbstractItemModel):
             "Scenario alternative": "ScenarioAlternative",
             "Parameter value list": "ParameterValueList",
         }[new_type]
-        root_mapping = import_mapping_from_dict({"map_type": map_type})
+        root_mapping = default_import_mapping(map_type)
         self.set_root_mapping(table_row, list_row, root_mapping)
 
     def _set_mapping_data(self, flattened_mappings, index, value, role):


### PR DESCRIPTION
Importer was using legacy functionality in `spinedb_api` to get blank mappings when user changed the mapping type. This did not work e.g. with Entity group mappings since those did not exist in pre-0.7 world.

Fixes spine-tools/Spine-Toolbox#2662
spine-tools/Spine-Toolbox# (issue)

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
