### PR TITLE
Support PySide 6.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 requires-python = ">=3.8.1, <3.12"
 dependencies = [
-    "pyside6 >= 6.5.0, != 6.5.3, < 6.6",
+    "pyside6 >= 6.5.0, != 6.5.3, != 6.6.3",
     "pyodbc >=4.0",
     # v1.4 does not pass tests
     "sqlalchemy >=1.3, <1.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git@0.8-dev#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git@0.8-dev#egg=spine_engine
--e git+https://github.com/spine-tools/Spine-Toolbox.git@0.8-dev#egg=spinetoolbox
+-e git+https://github.com/spine-tools/Spine-Toolbox.git@support_pyside66#egg=spinetoolbox
 -e .[dev]


### PR DESCRIPTION
This PR updates `spine-items` to allow using PySide6 6.6.

Re spine-tools/Spine-Toolbox#2345

## Checklist before merging
- [x] Code has been formatted by black
- [x] Unit tests pass
