### PR TITLE
Don't install coverage while installing the package

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -43,6 +43,9 @@ jobs:
     - name: List packages
       run:
         pip list
+    - name: Install coverage
+      run: |
+        python -m pip install coverage[toml]
     - name: Run tests
       run: |
         if [ "$RUNNER_OS" != "Windows" ]; then

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -44,7 +44,7 @@ jobs:
       run:
         pip list
     - name: Install coverage
-      run: |
+      run:
         python -m pip install coverage[toml]
     - name: Run tests
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,6 @@ dependencies = [
 [project.urls]
 Repository = "https://github.com/spine-tools/spine-items"
 
-[project.optional-dependencies]
-dev = ["coverage[toml]"]
-
 [build-system]
 requires = ["setuptools>=64", "setuptools_scm[toml]>=6.2", "wheel", "build"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/spine-tools/Spine-Database-API.git@0.8-dev#egg=spinedb_api
 -e git+https://github.com/spine-tools/spine-engine.git@0.8-dev#egg=spine_engine
 -e git+https://github.com/spine-tools/Spine-Toolbox.git@0.8-dev#egg=spinetoolbox
--e .[dev]
+-e .


### PR DESCRIPTION
- Instead, add a step to Github test runner action to install coverage

Re spine-tools/Spine-Toolbox#2268

## Checklist before merging
- [x] Unit tests pass
