### PR TITLE
Lift Python version upper limit

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-22.04]
-        python-version: [3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -26,8 +26,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: pip
         cache-dependency-path: |
-          requirements.txt
           pyproject.toml
+          requirements.txt
+          dev-requirements.txt
     - name: Display Python version
       run:
          python -c "import sys; print(sys.version)"
@@ -41,15 +42,11 @@ jobs:
         PYTHONUTF8: 1
       run: |
         python -m pip install --upgrade pip
-        python -m pip install wheel
-        python -m pip install --no-deps -e .
         python -m pip install -r requirements.txt
+        python -m pip install -r dev-requirements.txt
     - name: List packages
       run:
         pip list
-    - name: Install coverage
-      run:
-        python -m pip install coverage[toml]
     - name: Run tests
       run: |
         if [ "$RUNNER_OS" != "Windows" ]; then

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spine Items
 
-[![Python](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10%20|%203.11-blue.svg)](https://www.python.org/downloads/release/python-379/)
+[![Python](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10%20|%203.11|%203.12-blue.svg)](https://www.python.org/downloads/release/python-379/)
 [![Unit tests](https://github.com/spine-tools/spine-items/workflows/Unit%20tests/badge.svg)](https://github.com/spine-tools/spine-items/actions?query=workflow%3A"Unit+tests")
 [![codecov](https://codecov.io/gh/spine-tools/spine-items/branch/master/graph/badge.svg)](https://codecov.io/gh/spine-tools/spine-items)
 [![PyPI version](https://badge.fury.io/py/spine-items.svg)](https://badge.fury.io/py/spine-items)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,1 @@
+coverage[toml]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,18 +7,12 @@ description = "Spine project items"
 keywords = ["energy system modelling", "workflow", "optimisation", "database"]
 readme = {file = "README.md", content-type = "text/markdown"}
 classifiers = [
-	    "Programming Language :: Python :: 3",
-	    "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
-	    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
+    "Operating System :: OS Independent",
 ]
-requires-python = ">=3.8.1, <3.12"
+requires-python = ">=3.8.1"
 dependencies = [
-    "pyside6 >= 6.5.0, != 6.5.3, != 6.6.3",
-    "pyodbc >=4.0",
-    # v1.4 does not pass tests
-    "sqlalchemy >=1.3, <1.4",
-    "pygments >=2.8",
-    "numpy >=1.20.2",
     "spinedb_api>=0.31.1",
     "spine_engine>=0.24.0",
     # "spinetoolbox >=0.6.18",
@@ -41,9 +35,9 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 exclude = [
-	"bin*",
-	"fig*",
-	"tests*",
+    "bin*",
+    "fig*",
+    "tests*",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
This PR removes the Python version restriction < 3.12 from Spine-Items.

Re spine-tools/Spine-Toolbox#2522

## Checklist before merging
- [x] Unit tests pass
