### PR TITLE
Fix traceback caused by tool main file renaming

### DIFF
--- a/spine_items/tool/widgets/tool_specification_editor_window.py
+++ b/spine_items/tool/widgets/tool_specification_editor_window.py
@@ -876,7 +876,11 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
             self, "Select existing main program file", self._project.project_dir, "*.*"
         )
         file_path = answer[0]
-        existing_file_paths = [os.path.join(self.includes_main_path, i) for i in self.spec_dict.get("includes", [])]
+        existing_file_paths = [
+            os.path.join(self.includes_main_path, i)
+            for i in self.spec_dict.get("includes", [])
+            if os.path.exists(os.path.join(self.includes_main_path, i))
+        ]
         if not file_path:  # Cancel button clicked
             return
         for i, existing_file in enumerate(existing_file_paths):

--- a/tests/tool/widgets/test_toolSpecificationEditorWindow.py
+++ b/tests/tool/widgets/test_toolSpecificationEditorWindow.py
@@ -386,10 +386,12 @@ class TestToolSpecificationEditorWindow(unittest.TestCase):
         mock_logger = mock.MagicMock()
         script_file_name = "hello.jl"
         script_file_name2 = "hello2.jl"
+        script_file_name3 = "hello3.jl"
         data_file_name = "data.csv"
         file_path = Path(self._temp_dir.name, script_file_name)
         file_path2 = Path(self._temp_dir.name, script_file_name2)
         file_path3 = Path(self._temp_dir.name, data_file_name)
+        file_path4 = Path(self._temp_dir.name, script_file_name3)
         # Make files so os.path.samefile() works
         with open(file_path, "w") as h:
             h.writelines(["println('Hello world')"])  # Make hello.jl
@@ -418,6 +420,13 @@ class TestToolSpecificationEditorWindow(unittest.TestCase):
                 self.tool_specification_widget.browse_main_program_file()
                 mock_mb.assert_called()
             self.assertEqual("hello2.jl", os.path.split(self.tool_specification_widget._current_main_program_file())[1])
+            # Rename the current main program file hello2.jl -> hello3.jl
+            os.rename(file_path2, file_path4)
+            mock_fd_gofn.return_value = [file_path4]
+            # Select renamed main program file hello3.jl
+            self.tool_specification_widget.browse_main_program_file()
+            mock_fd_gofn.assert_called()
+            self.assertEqual("hello3.jl", os.path.split(self.tool_specification_widget._current_main_program_file())[1])
         # Test new_main_program_file()
         with mock.patch(
             "spine_items.tool.widgets.tool_specification_editor_window.QFileDialog.getSaveFileName"


### PR DESCRIPTION
Fixes spine-tools/Spine-Toolbox#2890

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
