### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+-   repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+    -   id: isort
+-   repo: https://github.com/python/black
+    rev: 24.4.2
+    hooks:
+    -   id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,13 +49,14 @@ ignore_errors = true
 
 [tool.black]
 line-length = 120
-exclude = '\.git|ui|resources_icons_rc.py|version.py'
+force-exclude = '\.git|ui|resources_icons_rc.py|version.py'
 
 [tool.isort]
 profile = "black"
 lines_between_sections = 0
 force_sort_within_sections = true
 honor_case_in_force_sorted_sections = true
+skip = [".git", "spine_items/resources_icons_rc.py", "spine_items/resources_logos_rc.py", "spinetoolbox/version.py"]
 skip_glob = ["spine_items/ui/*", "spine_items/*/ui/*", "spine_items/version.py"]
 line_length = 120
 known_first_party = ["spine_engine", "spinedb_api", "spinetoolbox"]


### PR DESCRIPTION
Now both isort and black are included in the pre-commit hooks.

Fixes spine-tools/Spine-Toolbox#2897

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
