### PR TITLE
Fix numpy 2.0 compatibility issue in Exporter

### DIFF
--- a/spine_items/exporter/preview_table_writer.py
+++ b/spine_items/exporter/preview_table_writer.py
@@ -48,7 +48,7 @@ def _sanitize(x):
     Returns:
         float or int or str: sanitized value
     """
-    if isinstance(x, numpy.float_):
+    if isinstance(x, numpy.float64):
         return float(x)
     if not isinstance(x, (float, str, int)) and x is not None:
         return str(x)

--- a/tests/exporter/test_output_channel.py
+++ b/tests/exporter/test_output_channel.py
@@ -1,5 +1,6 @@
 ######################################################################################################################
-# Copyright (C) 2017-2023 Spine project consortium
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Items contributors
 # This file is part of Spine Items.
 # Spine Items is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
 # Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)

--- a/tests/exporter/test_preview_table_writer.py
+++ b/tests/exporter/test_preview_table_writer.py
@@ -9,3 +9,26 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
+import unittest
+import numpy
+from spine_items.exporter.preview_table_writer import TableWriter
+
+
+class TestTableWriter(unittest.TestCase):
+    def setUp(self):
+        self._writer = TableWriter()
+        self._writer.start()
+
+    def tearDown(self):
+        self._writer.finish()
+
+    def test_write_row_float64_converted_to_float(self):
+        self.assertTrue(self._writer.start_table("My table", {}))
+        self.assertTrue(self._writer.write_row([numpy.float64(2.3)]))
+        self._writer.finish_table()
+        tables = self._writer.tables
+        self.assertEqual(tables, {"My table": [[2.3]]})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/exporter/test_specification.py
+++ b/tests/exporter/test_specification.py
@@ -1,5 +1,6 @@
 ######################################################################################################################
-# Copyright (C) 2017-2023 Spine project consortium
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Items contributors
 # This file is part of Spine Items.
 # Spine Items is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
 # Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)

--- a/tests/exporter/test_utils.py
+++ b/tests/exporter/test_utils.py
@@ -1,5 +1,6 @@
 ######################################################################################################################
-# Copyright (C) 2017-2023 Spine project consortium
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Items contributors
 # This file is part of Spine Items.
 # Spine Items is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
 # Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)

--- a/tests/exporter/widgets/test_preview_updater.py
+++ b/tests/exporter/widgets/test_preview_updater.py
@@ -1,5 +1,6 @@
 ######################################################################################################################
-# Copyright (C) 2017-2023 Spine project consortium
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Items contributors
 # This file is part of Spine Items.
 # Spine Items is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
 # Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)

--- a/tests/importer/widgets/test_import_sources.py
+++ b/tests/importer/widgets/test_import_sources.py
@@ -1,5 +1,6 @@
 ######################################################################################################################
-# Copyright (C) 2017-2023 Spine project consortium
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Items contributors
 # This file is part of Spine Toolbox.
 # Spine Toolbox is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
 # Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)


### PR DESCRIPTION
`float_` is no more in `numpy` 2.0.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
