### PR TITLE
Fix regular expression hints in Exporter

### DIFF
--- a/spine_items/exporter/ui/value_type_filter_editor.py
+++ b/spine_items/exporter/ui/value_type_filter_editor.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'value_type_filter_editor.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.5.2
+## Created by: Qt User Interface Compiler version 6.6.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -33,7 +33,7 @@ class Ui_Form(object):
     def setupUi(self, Form):
         if not Form.objectName():
             Form.setObjectName(u"Form")
-        Form.resize(354, 141)
+        Form.resize(354, 138)
         self.verticalLayout = QVBoxLayout(Form)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.regexp_line_edit = QLineEdit(Form)
@@ -68,6 +68,6 @@ class Ui_Form(object):
         Form.setWindowTitle(QCoreApplication.translate("Form", u"Form", None))
         self.regexp_line_edit.setPlaceholderText(QCoreApplication.translate("Form", u"Type regular expression here...", None))
         self.label_2.setText(QCoreApplication.translate("Form", u"<html><head/><body><p><a href=\"https://docs.python.org/3/library/re.html#regular-expression-syntax\"><span style=\" text-decoration: underline; color:#0000ff;\">Link</span></a> to regular expression syntax.</p></body></html>", None))
-        self.label.setText(QCoreApplication.translate("Form", u"<html><head/><body><p>Available types for filtering:<br><span style=\" font-weight:600;\">single_value</span> - scalars, strings, booleans<br><span style=\" font-weight:600;\">array</span> - arrays<br><span style=\" font-weight:600;\">time_series</span> - time series<br><span style=\" font-weight:600;\">time_pattern</span> - time patterns<br><span style=\" font-weight:600;\">1d_map</span>, <span style=\" font-weight:600;\">2d_map</span>,... - maps of <span style=\" font-style:italic;\">n</span>d dimensions</p></body></html>", None))
+        self.label.setText(QCoreApplication.translate("Form", u"<html><head/><body><p>Available types for filtering:<br/><span style=\" font-weight:700;\">float</span>, <span style=\" font-weight:700;\">str</span>, <span style=\" font-weight:700;\">bool</span> - numbers, strings, booleans<br/><span style=\" font-weight:700;\">array</span>, <span style=\" font-weight:700;\">time_series</span>, <span style=\" font-weight:700;\">time_pattern</span><br/><span style=\" font-weight:700;\">1d_map</span>, <span style=\" font-weight:700;\">2d_map</span>,... - maps of <span style=\" font-style:italic;\">n</span>d dimensions</p></body></html>", None))
     # retranslateUi
 

--- a/spine_items/exporter/ui/value_type_filter_editor.ui
+++ b/spine_items/exporter/ui/value_type_filter_editor.ui
@@ -2,6 +2,7 @@
 <!--
 ######################################################################################################################
 # Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Items contributors
 # This file is part of Spine Items.
 # Spine Items is free software: you can redistribute it and\/or modify it under the terms of the GNU Lesser General
 # Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
@@ -19,7 +20,7 @@
     <x>0</x>
     <y>0</y>
     <width>354</width>
-    <height>141</height>
+    <height>138</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -55,7 +56,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Available types for filtering:&lt;br&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;single_value&lt;/span&gt; - scalars, strings, booleans&lt;br&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;array&lt;/span&gt; - arrays&lt;br&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;time_series&lt;/span&gt; - time series&lt;br&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;time_pattern&lt;/span&gt; - time patterns&lt;br&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;1d_map&lt;/span&gt;, &lt;span style=&quot; font-weight:600;&quot;&gt;2d_map&lt;/span&gt;,... - maps of &lt;span style=&quot; font-style:italic;&quot;&gt;n&lt;/span&gt;d dimensions&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Available types for filtering:&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;float&lt;/span&gt;, &lt;span style=&quot; font-weight:700;&quot;&gt;str&lt;/span&gt;, &lt;span style=&quot; font-weight:700;&quot;&gt;bool&lt;/span&gt; - numbers, strings, booleans&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;array&lt;/span&gt;, &lt;span style=&quot; font-weight:700;&quot;&gt;time_series&lt;/span&gt;, &lt;span style=&quot; font-weight:700;&quot;&gt;time_pattern&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;1d_map&lt;/span&gt;, &lt;span style=&quot; font-weight:700;&quot;&gt;2d_map&lt;/span&gt;,... - maps of &lt;span style=&quot; font-style:italic;&quot;&gt;n&lt;/span&gt;d dimensions&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>

--- a/spine_items/exporter/widgets/specification_editor_window.py
+++ b/spine_items/exporter/widgets/specification_editor_window.py
@@ -551,10 +551,7 @@ class SpecificationEditorWindow(SpecificationEditorWindowBase):
     def _toggle_all_enabled(self):
         """Pushes a command that enables or disables all mappings to undo stack."""
         for row in range(self._mappings_table_model.rowCount()):
-            if (
-                self._mappings_table_model.index(row, 0).data(Qt.ItemDataRole.CheckStateRole)
-                == Qt.CheckState.Unchecked.value
-            ):
+            if self._mappings_table_model.index(row, 0).data(Qt.ItemDataRole.CheckStateRole) == Qt.CheckState.Unchecked:
                 self._undo_stack.push(EnableAllMappings(self._mappings_table_model))
                 return
         self._undo_stack.push(DisableAllMappings(self._mappings_table_model))

--- a/spine_items/importer/ui/import_editor_window.py
+++ b/spine_items/importer/ui/import_editor_window.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'import_editor_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.7.2
+## Created by: Qt User Interface Compiler version 6.6.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -73,7 +73,7 @@ class Ui_MainWindow(object):
         self.browse_source_button = QToolButton(self.centralwidget)
         self.browse_source_button.setObjectName(u"browse_source_button")
         icon = QIcon()
-        icon.addFile(u":/icons/folder-open-solid.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
+        icon.addFile(u":/icons/folder-open-solid.svg", QSize(), QIcon.Normal, QIcon.Off)
         self.browse_source_button.setIcon(icon)
 
         self.horizontalLayout_2.addWidget(self.browse_source_button)


### PR DESCRIPTION
`single_value` value type does not exist anymore. Instead, we have `float`, `bool` and `str`.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
