### PR TITLE
Make Exporter's preview a smoother experience

### DIFF
--- a/spine_items/exporter/ui/specification_editor.py
+++ b/spine_items/exporter/ui/specification_editor.py
@@ -71,7 +71,7 @@ class Ui_MainWindow(object):
 
         self.live_preview_check_box = QCheckBox(self.centralwidget)
         self.live_preview_check_box.setObjectName(u"live_preview_check_box")
-        self.live_preview_check_box.setChecked(False)
+        self.live_preview_check_box.setChecked(True)
 
         self.horizontalLayout_3.addWidget(self.live_preview_check_box)
 

--- a/spine_items/exporter/ui/specification_editor.ui
+++ b/spine_items/exporter/ui/specification_editor.ui
@@ -65,7 +65,7 @@
          <string>Live preview</string>
         </property>
         <property name="checked">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/spine_items/exporter/widgets/preview_updater.py
+++ b/spine_items/exporter/widgets/preview_updater.py
@@ -12,13 +12,15 @@
 
 """Contains :class:`PreviewUpdater`."""
 from copy import deepcopy
+from dataclasses import dataclass
+from multiprocessing import Pipe, Process
 from time import monotonic
-from PySide6.QtCore import QItemSelectionModel, QModelIndex, QObject, QRunnable, Qt, QThreadPool, Signal, Slot
+from PySide6.QtCore import QItemSelectionModel, QModelIndex, Qt, QTimer, Slot
 from PySide6.QtWidgets import QFileDialog
 from spinedb_api import DatabaseMapping, SpineDBAPIError, SpineDBVersionError
-from spinedb_api.export_mapping.group_functions import NoGroup
+from spinedb_api.export_mapping.export_mapping import ExportMapping
+from spinedb_api.export_mapping.group_functions import GroupFunction
 from spinedb_api.spine_io.exporters.writer import write
-from spinetoolbox.helpers import busy_effect
 from ..mvcmodels.full_url_list_model import FullUrlListModel
 from ..mvcmodels.mappings_table_model import MappingsTableModel
 from ..mvcmodels.preview_table_model import PreviewTableModel
@@ -72,7 +74,11 @@ class PreviewUpdater:
         self._preview_tree_model.rowsInserted.connect(self._expand_tree_after_table_insert)
         self._preview_table_model = PreviewTableModel()
         self._stamps = dict()
-        self._thread_pool = QThreadPool()
+        self._writer_connection, connection = Pipe()
+        self._writer_process = Process(target=write_task_loop, args=(connection,))
+        self._writer_timer = QTimer(window)
+        self._writer_timer.setInterval(100)
+        self._writer_timer.timeout.connect(self._communicate)
         self._mapping_tables = dict()
         self._ui.preview_tree_view.setModel(self._preview_tree_model)
         self._ui.preview_tree_view.selectionModel().currentChanged.connect(self._change_table)
@@ -404,18 +410,38 @@ class PreviewUpdater:
         id_ = (self._current_url, mapping_name)
         stamp = monotonic()
         self._stamps[id_] = stamp
-        worker = _Worker(
-            self._current_url,
-            mapping_name,
-            deepcopy(mapping_spec.root),
-            mapping_spec.always_export_header,
-            stamp,
-            max_tables,
-            max_rows,
-            mapping_spec.group_fn,
+        if not self._writer_process.is_alive():
+            self._writer_process.start()
+        self._writer_connection.send(
+            WriteTableTask(
+                self._current_url,
+                mapping_name,
+                stamp,
+                deepcopy(mapping_spec.root),
+                mapping_spec.always_export_header,
+                max_tables,
+                max_rows,
+                mapping_spec.group_fn,
+            )
         )
-        worker.signals.table_written.connect(self._add_or_update_data)
-        self._thread_pool.start(worker)
+        if not self._writer_timer.isActive():
+            self._writer_timer.start()
+
+    @Slot()
+    def _communicate(self):
+        """Periodically communicates with the writer process."""
+        self._writer_timer.stop()
+        if self._writer_connection.poll():
+            # Receive and process one table at time to keep the UI responsive
+            message = self._writer_connection.recv()
+            if message == "finished":
+                return
+            self._add_or_update_data(*message)
+        if self._stamps:
+            self._writer_timer.setInterval(50)
+            self._writer_timer.start()
+        else:
+            self._writer_timer.setInterval(100)
 
     @Slot(tuple, str, object, float)
     def _add_or_update_data(self, worker_id, mapping_name, data, stamp):
@@ -426,7 +452,7 @@ class PreviewUpdater:
             worker_id (tuple): a worker identifier
             mapping_name (str): mapping's name
             data (dict): mapping from table name to table
-            stamp (float): worker's time stamp
+            stamp (float): task's time stamp
         """
         current_stamp = self._stamps.pop(worker_id, None)
         if stamp != current_stamp:
@@ -467,63 +493,87 @@ class PreviewUpdater:
         self._reload_preview()
 
     def tear_down(self):
-        """Stops all workers."""
+        """Stops the writer process and cleans up."""
+        self._writer_connection.send("quit")
+        self._writer_timer.stop()
         self._stamps.clear()
-        self._thread_pool.clear()
-        self._thread_pool.deleteLater()
         self._url_model.rowsInserted.disconnect(self._enable_controls_after_url_insertion)
         self._url_model.modelReset.disconnect(self._enable_controls)
         self._url_model.destroyed.disconnect(self._forget_url_model)
+        if self._writer_process.is_alive():
+            while self._writer_connection.poll():
+                # Drain the pipe, otherwise writer process's send() may block and the join() below hangs.
+                self._writer_connection.recv()
+            self._writer_process.join()
 
 
-class _Worker(QRunnable):
-    class Signals(QObject):
-        table_written = Signal(tuple, str, object, float)
+@dataclass(frozen=True)
+class WriteTableTask:
+    url: str
+    mapping_name: str
+    stamp: float
+    mapping: ExportMapping
+    always_export_header: bool
+    max_tables: int
+    max_rows: int
+    group_fn: GroupFunction
 
-    def __init__(
-        self, url, mapping_name, mapping, always_export_header, stamp, max_tables=20, max_rows=20, group_fn=NoGroup.NAME
-    ):
-        super().__init__()
-        self._url = url
-        self._mapping_name = mapping_name
-        self._mapping = mapping
-        self._always_export_header = always_export_header
-        self._max_tables = max_tables
-        self._max_rows = max_rows
-        self._group_fn = group_fn
-        self._stamp = stamp
-        self.signals = self.Signals()
 
-    @busy_effect
-    def run(self):
-        try:
-            db_map = DatabaseMapping(self._url)
-        except SpineDBVersionError:
-            tables = {"error": [["unsupported database version"]]}
-            self.signals.table_written.emit((self._url, self._mapping_name), self._mapping_name, tables, self._stamp)
-            return
-        except SpineDBAPIError as error:
-            tables = {"error": [[str(error)]]}
-            self.signals.table_written.emit((self._url, self._mapping_name), self._mapping_name, tables, self._stamp)
-            return
-        try:
-            writer = TableWriter()
-            write(
-                db_map,
-                writer,
-                self._mapping,
-                empty_data_header=self._always_export_header,
-                max_tables=self._max_tables,
-                max_rows=self._max_rows,
-                group_fns=self._group_fn,
-            )
-            self.signals.table_written.emit(
-                (self._url, self._mapping_name), self._mapping_name, writer.tables, self._stamp
-            )
-        except SpineDBAPIError as error:
-            tables = {"error": [[str(error)]]}
-            self.signals.table_written.emit((self._url, self._mapping_name), self._mapping_name, tables, self._stamp)
-            return
-        finally:
+def write_task_loop(connection):
+    """A task loop that processes table writing tasks.
+
+    Args:
+        connection (Connection): Pipe endpoint to communicate with the loop
+    """
+    db_map = None
+    tasks = []
+    try:
+        while True:
+            if connection.poll() or not tasks:
+                while True:
+                    task = connection.recv()
+                    if task == "quit":
+                        return
+                    tasks.append(task)
+                    if not connection.poll():
+                        break
+            next_task = tasks.pop(0)
+            try:
+                if db_map is not None and next_task.url != db_map.db_url:
+                    db_map.close()
+                    db_map = None
+                if db_map is None:
+                    db_map = DatabaseMapping(next_task.url)
+                tables = _write_tables(db_map, next_task)
+            except SpineDBVersionError:
+                tables = {"error": [["unsupported database version"]]}
+            except SpineDBAPIError as error:
+                tables = {"error": [[str(error)]]}
+            connection.send(((next_task.url, next_task.mapping_name), next_task.mapping_name, tables, next_task.stamp))
+    finally:
+        if db_map is not None:
             db_map.close()
-            self.signals.deleteLater()
+        connection.send("finished")
+
+
+def _write_tables(db_map, write_task):
+    """Creates preview tables with given parameters.
+
+    Args:
+        db_map (DatabaseMapping): database mapping
+        write_task (WriteTableTask): task parameters
+
+    Returns:
+        tuple: mappings from table names to tables (list of rows)
+    """
+    writer = TableWriter()
+    write(
+        db_map,
+        writer,
+        write_task.mapping,
+        empty_data_header=write_task.always_export_header,
+        max_tables=write_task.max_tables,
+        max_rows=write_task.max_rows,
+        group_fns=write_task.group_fn,
+    )
+    return writer.tables

--- a/tests/exporter/widgets/test_preview_updater.py
+++ b/tests/exporter/widgets/test_preview_updater.py
@@ -11,11 +11,18 @@
 ######################################################################################################################
 
 """Unit tests for the ``preview_updater`` module."""
+from multiprocessing import Pipe, Process
+import pathlib
+from tempfile import TemporaryDirectory
 import unittest
 from unittest import mock
 from PySide6.QtWidgets import QApplication, QComboBox, QWidget
 from spine_items.exporter.mvcmodels.full_url_list_model import FullUrlListModel
-from spine_items.exporter.widgets.preview_updater import PreviewUpdater
+from spine_items.exporter.widgets.preview_updater import PreviewUpdater, WriteTableTask, write_task_loop
+from spinedb_api import DatabaseMapping
+from spinedb_api.export_mapping.export_mapping import AlternativeMapping
+from spinedb_api.export_mapping.group_functions import NoGroup
+from tests.mock_helpers import parent_widget
 
 
 class TestPreviewUpdater(unittest.TestCase):
@@ -31,22 +38,95 @@ class TestPreviewUpdater(unittest.TestCase):
         self._parent_widget.deleteLater()
 
     def test_deleting_url_model_does_not_break_tear_down(self):
-        window = mock.MagicMock()
-        ui = mock.MagicMock()
-        ui.database_url_combo_box = QComboBox(self._parent_widget)
-        url_model = FullUrlListModel()
-        mappings_table_model = mock.MagicMock()
-        mappings_proxy_model = mock.MagicMock()
-        mapping_editor_table_model = mock.MagicMock()
-        project_dir = ""
-        preview_updater = PreviewUpdater(
-            window, ui, url_model, mappings_table_model, mappings_proxy_model, mapping_editor_table_model, project_dir
-        )
-        # It is difficult to get the url_model deleted on C++ side.
-        # We simulate it by emitting destroyed manually.
-        url_model.destroyed.emit()
-        self.assertIsNot(preview_updater._url_model, url_model)
-        preview_updater.tear_down()
+        with parent_widget() as window:
+            setattr(window, "current_mapping_about_to_change", mock.MagicMock())
+            setattr(window, "current_mapping_changed", mock.MagicMock())
+            ui = mock.MagicMock()
+            ui.database_url_combo_box = QComboBox(self._parent_widget)
+            url_model = FullUrlListModel()
+            mappings_table_model = mock.MagicMock()
+            mappings_proxy_model = mock.MagicMock()
+            mapping_editor_table_model = mock.MagicMock()
+            project_dir = ""
+            preview_updater = PreviewUpdater(
+                window,
+                ui,
+                url_model,
+                mappings_table_model,
+                mappings_proxy_model,
+                mapping_editor_table_model,
+                project_dir,
+            )
+            # It is difficult to get the url_model deleted on C++ side.
+            # We simulate it by emitting destroyed manually.
+            url_model.destroyed.emit()
+            self.assertIsNot(preview_updater._url_model, url_model)
+            preview_updater.tear_down()
+
+
+class TestWriteTaskLoop(unittest.TestCase):
+    def test_quit(self):
+        connection1, connection2 = Pipe()
+        connection1.send("quit")
+        write_task_loop(connection2)
+        self.assertTrue(connection1.poll())
+        self.assertTrue(connection1.recv(), "finished")
+
+    def test_quitting_takes_precedence_over_writing(self):
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + str(pathlib.Path(temp_dir) / "db.sqlite")
+            with DatabaseMapping(url, create=True) as db_map:
+                db_map.add_alternative_item(name="alt1")
+                db_map.add_alternative_item(name="alt2")
+                db_map.commit_session("Add test data.")
+            connection1, connection2 = Pipe()
+            connection1.send(WriteTableTask(url, "my mapping", 2.3, AlternativeMapping(0), True, 1, 3, NoGroup.NAME))
+            connection1.send("quit")
+            write_task_loop(connection2)
+            self.assertTrue(connection1.poll())
+            self.assertTrue(connection1.recv(), "finished")
+
+    def test_writing(self):
+        connection1, connection2 = Pipe()
+        process = Process(target=write_task_loop, args=(connection2,))
+        process.start()
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + str(pathlib.Path(temp_dir) / "db.sqlite")
+            with DatabaseMapping(url, create=True) as db_map:
+                db_map.add_alternative_item(name="alt1")
+                db_map.add_alternative_item(name="alt2")
+                db_map.commit_session("Add test data.")
+            connection1.send(WriteTableTask(url, "my mapping", 2.3, AlternativeMapping(0), True, 1, 3, NoGroup.NAME))
+            tables = connection1.recv()
+            self.assertEqual(tables, ((url, "my mapping"), "my mapping", {None: [["Base"], ["alt1"], ["alt2"]]}, 2.3))
+        connection1.send("quit")
+        self.assertTrue(connection1.recv(), "finished")
+        process.join()
+
+    def test_change_database_between_writes(self):
+        connection1, connection2 = Pipe()
+        process = Process(target=write_task_loop, args=(connection2,))
+        process.start()
+        with TemporaryDirectory() as temp_dir:
+            url = "sqlite:///" + str(pathlib.Path(temp_dir) / "db1.sqlite")
+            with DatabaseMapping(url, create=True) as db_map:
+                db_map.add_alternative_item(name="alt1")
+                db_map.add_alternative_item(name="alt2")
+                db_map.commit_session("Add test data.")
+            connection1.send(WriteTableTask(url, "my mapping", 2.3, AlternativeMapping(0), True, 1, 3, NoGroup.NAME))
+            tables = connection1.recv()
+            self.assertEqual(tables, ((url, "my mapping"), "my mapping", {None: [["Base"], ["alt1"], ["alt2"]]}, 2.3))
+            url = "sqlite:///" + str(pathlib.Path(temp_dir) / "db2.sqlite")
+            with DatabaseMapping(url, create=True) as db_map:
+                db_map.add_alternative_item(name="alt3")
+                db_map.add_alternative_item(name="alt4")
+                db_map.commit_session("Add test data.")
+            connection1.send(WriteTableTask(url, "my mapping", 23.0, AlternativeMapping(0), True, 1, 3, NoGroup.NAME))
+            tables = connection1.recv()
+            self.assertEqual(tables, ((url, "my mapping"), "my mapping", {None: [["Base"], ["alt3"], ["alt4"]]}, 23.0))
+        connection1.send("quit")
+        self.assertTrue(connection1.recv(), "finished")
+        process.join()
 
 
 if __name__ == "__main__":

--- a/tests/importer/widgets/test_import_mapping_options.py
+++ b/tests/importer/widgets/test_import_mapping_options.py
@@ -21,6 +21,7 @@ from spine_items.importer.mvcmodels.mappings_model_roles import Role
 from spine_items.importer.ui.import_editor_window import Ui_MainWindow
 from spine_items.importer.widgets.import_mapping_options import ImportMappingOptions
 from spinetoolbox.helpers import signal_waiter
+from tests.mock_helpers import parent_widget
 
 
 class TestImportMappingOptions(unittest.TestCase):
@@ -87,15 +88,6 @@ class TestImportMappingOptions(unittest.TestCase):
             "table_row_types": {},
             "source_type": "ExcelConnector",
         }
-
-
-@contextmanager
-def parent_widget():
-    parent = QMainWindow()
-    try:
-        yield parent
-    finally:
-        parent.deleteLater()
 
 
 if __name__ == "__main__":

--- a/tests/mock_helpers.py
+++ b/tests/mock_helpers.py
@@ -11,10 +11,11 @@
 ######################################################################################################################
 
 """Classes and functions that can be shared among unit test modules."""
+from contextlib import contextmanager
 import os.path
 from unittest.mock import MagicMock, patch
 from PySide6.QtGui import QStandardItemModel
-from PySide6.QtWidgets import QApplication, QWidget
+from PySide6.QtWidgets import QApplication, QMainWindow, QWidget
 from spinetoolbox.ui_main import ToolboxUI
 
 
@@ -140,3 +141,12 @@ def clean_up_toolbox(toolbox):
     # Delete undo stack explicitly to prevent emitting certain signals well after ToolboxUI has been destroyed.
     toolbox.undo_stack.deleteLater()
     toolbox.deleteLater()
+
+
+@contextmanager
+def parent_widget():
+    parent = QMainWindow()
+    try:
+        yield parent
+    finally:
+        parent.deleteLater()


### PR DESCRIPTION
This PR makes Exporter's Specification editor run much smoother while updating the preview tables. Since they do not freeze the UI anymore, previews are enable by default now. If we experience unresponsive UI again, we can change the default back to disabled.

Fixes spine-tools/Spine-Toolbox#2898

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
