### PR TITLE
Fix constructing a Data Store with incomplete URL

### DIFF
--- a/spine_items/data_store/data_store.py
+++ b/spine_items/data_store/data_store.py
@@ -71,7 +71,7 @@ class DataStore(ProjectItem):
         self._purge_dialog = None
         self._database_validator = DatabaseConnectionValidator(self)
         db_map = self.get_db_map_for_ds()
-        # Notify db manager about the Data Stores in the project so it can notify abobut the dirtyness of them
+        # Notify db manager about the Data Stores in the project, so it can notify about the dirtiness of them
         self._toolbox.db_mngr.add_data_store_db_map(db_map, self)
 
     def get_db_map_for_ds(self):
@@ -100,9 +100,9 @@ class DataStore(ProjectItem):
         """Return a complete url dictionary from the given dict or string"""
         base_url = {"dialect": "", "username": "", "password": "", "host": "", "port": "", "database": "", "schema": ""}
         if isinstance(url, dict):
-            if url.get("dialect") == "sqlite" and "database" in url and url["database"] is not None:
+            if url.get("dialect") == "sqlite" and (database := url.get("database")):
                 # Convert relative database path back to absolute
-                url["database"] = os.path.abspath(os.path.join(self._project.project_dir, url["database"]))
+                url["database"] = os.path.abspath(os.path.join(self._project.project_dir, database))
             for key, value in url.items():
                 if value is not None:
                     base_url[key] = value

--- a/spine_items/data_store/data_store.py
+++ b/spine_items/data_store/data_store.py
@@ -76,8 +76,9 @@ class DataStore(ProjectItem):
 
     def get_db_map_for_ds(self):
         """Returns the db map for the Data Store"""
-        if self._url.get("dialect"):
-            return self._toolbox.db_mngr.get_db_map(self.sql_alchemy_url(), self._logger, codename=self.name)
+        sa_url = self.sql_alchemy_url()
+        if sa_url is not None:
+            return self._toolbox.db_mngr.get_db_map(sa_url, self._logger, codename=self.name)
         return None
 
     @staticmethod
@@ -545,5 +546,6 @@ class DataStore(ProjectItem):
         """See base class"""
         self._database_validator.wait_for_finish()
         db_map = self.get_db_map_for_ds()
-        self._toolbox.db_mngr.remove_data_store_db_map(db_map, self)
+        if db_map is not None:
+            self._toolbox.db_mngr.remove_data_store_db_map(db_map, self)
         super().tear_down()


### PR DESCRIPTION
This fixes wonky behavior when project was saved and closed without properly defining a Data Store's URL.

Fixes spine-tools/Spine-Toolbox#2915

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
