### PR TITLE
Fix bug in Data Store Properties

### DIFF
--- a/spine_items/widgets.py
+++ b/spine_items/widgets.py
@@ -376,7 +376,7 @@ class UrlSelectorWidget(QWidget):
         self._ui.comboBox_dialect.currentTextChanged.connect(lambda: self.url_changed.emit())
         self._ui.lineEdit_host.textChanged.connect(lambda: self.url_changed.emit())
         self._ui.lineEdit_port.textChanged.connect(lambda: self.url_changed.emit())
-        self._ui.lineEdit_database.textChanged.connect(lambda: self.url_changed.emit())
+        self._ui.lineEdit_database.editingFinished.connect(lambda: self.url_changed.emit())
         self._ui.lineEdit_username.textChanged.connect(lambda: self.url_changed.emit())
         self._ui.lineEdit_password.textChanged.connect(lambda: self.url_changed.emit())
 


### PR DESCRIPTION
Use editingFinished in the data base line edit, so the url_changed signal is not emitted on every key press while editing the path.

Fixes spine-tools/Spine-Toolbox#2930

## Checklist before merging
- [ ] Unit tests pass
