### PR TITLE
Make Tool spec editor's script editor dock non-closable

### DIFF
--- a/spine_items/tool/ui/tool_specification_form.py
+++ b/spine_items/tool/ui/tool_specification_form.py
@@ -220,6 +220,7 @@ class Ui_MainWindow(object):
         MainWindow.addDockWidget(Qt.BottomDockWidgetArea, self.dockWidget_io_files)
         self.dockWidget_program = QDockWidget(MainWindow)
         self.dockWidget_program.setObjectName(u"dockWidget_program")
+        self.dockWidget_program.setFeatures(QDockWidget.DockWidgetFloatable|QDockWidget.DockWidgetMovable)
         self.dockWidget_program.setAllowedAreas(Qt.BottomDockWidgetArea)
         self.dockWidgetContents = QWidget()
         self.dockWidgetContents.setObjectName(u"dockWidgetContents")

--- a/spine_items/tool/ui/tool_specification_form.ui
+++ b/spine_items/tool/ui/tool_specification_form.ui
@@ -264,6 +264,9 @@
    </widget>
   </widget>
   <widget class="QDockWidget" name="dockWidget_program">
+   <property name="features">
+    <set>QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
+   </property>
    <property name="allowedAreas">
     <set>Qt::BottomDockWidgetArea</set>
    </property>


### PR DESCRIPTION
Users tend to accidentally close the editor dock once they finish editing.

Re spine-tools/Spine-Toolbox#2963

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
