### PR TITLE
Fix issues in Importer specification editor

### DIFF
--- a/spine_items/importer/commands.py
+++ b/spine_items/importer/commands.py
@@ -607,37 +607,6 @@ class SetValueType(QUndoCommand):
         self._model.set_value_type(self._table_row, self._list_row, self._old_type)
 
 
-class SetUseBeforeAlternativeFlag(QUndoCommand):
-    """Command to set item mapping's use before alternative flag."""
-
-    def __init__(self, table_row, list_row, model, use_before_alternative, previous_mapping):
-        """
-        Args:
-            table_row (int): source table row index
-            list_row (int): mapping list row index
-            model (MappingsModel): model
-            use_before_alternative (bool): new flag value
-            previous_mapping (ImportMapping): previous mapping root
-        """
-        text = ("enable" if use_before_alternative else "disable") + " before alternative"
-        super().__init__(text)
-        self._table_row = table_row
-        self._list_row = list_row
-        self._model = model
-        self._use_before_alternative = use_before_alternative
-        self._previous_mapping_dict = [m.to_dict() for m in previous_mapping.flatten()]
-
-    def redo(self):
-        """Changes the use before alternative flag."""
-        self._model.set_use_before_alternative(self._table_row, self._list_row, self._use_before_alternative)
-
-    def undo(self):
-        """Restores the use before alternative flag."""
-        self._model.set_root_mapping(
-            self._table_row, self._list_row, import_mapping_from_dict(self._previous_mapping_dict)
-        )
-
-
 class SetSkipColumns(QUndoCommand):
     """Command to change item mapping's skip columns option."""
 

--- a/spine_items/importer/flattened_mappings.py
+++ b/spine_items/importer/flattened_mappings.py
@@ -34,7 +34,6 @@ from spinedb_api.import_mapping.import_mapping import (
     ParameterValueMapping,
     ParameterValueTypeMapping,
     ScenarioAlternativeMapping,
-    ScenarioBeforeAlternativeMapping,
     ScenarioMapping,
     check_validity,
 )
@@ -169,14 +168,6 @@ class FlattenedMappings:
         parameter_type = self.display_parameter_type()
         index_mapping = ParameterValueIndexMapping if parameter_type == "Value" else ParameterDefaultValueIndexMapping
         return len([m for m in self._components if isinstance(m, index_mapping)])
-
-    def uses_before_alternative(self):
-        """Checks if before alternative component is part of the mappings.
-
-        Returns:
-            bool: True if mapping uses before alternative, False otherwise
-        """
-        return any(isinstance(c, ScenarioBeforeAlternativeMapping) for c in reversed(self._components))
 
     def set_map_dimension_count(self, dimension_count):
         """Sets new dimensions for Map type value.

--- a/spine_items/importer/flattened_mappings.py
+++ b/spine_items/importer/flattened_mappings.py
@@ -38,7 +38,7 @@ from spinedb_api.import_mapping.import_mapping import (
     ScenarioMapping,
     check_validity,
 )
-from spinedb_api.mapping import Position, unflatten
+from spinedb_api.mapping import Position, is_pivoted, unflatten
 from spinedb_api.parameter_value import split_value_and_type
 from spinetoolbox.helpers import color_from_index
 from spinetoolbox.spine_db_manager import SpineDBManager
@@ -297,7 +297,7 @@ class FlattenedMappings:
         Returns:
             str: display position
         """
-        if self._is_component_pivoted(row):
+        if self.is_component_pivoted(row):
             return "Pivoted"
         component = self._components[self._display_to_logical[row]]
         if component.position == Position.hidden:
@@ -316,8 +316,12 @@ class FlattenedMappings:
             return "Column"
         return "Row"
 
-    def _is_component_pivoted(self, row):
-        return len(self._components) > 1 and self._components[0].is_pivoted() and row == len(self._display_names) - 1
+    def is_component_pivoted(self, row):
+        return (
+            len(self._components) > 1
+            and any(is_pivoted(c.position) or c.position == Position.header for c in self._components[:-1])
+            and row == len(self._display_names) - 1
+        )
 
     def set_display_position_type(self, row, position_type):
         """Sets component's position 'type'.
@@ -362,7 +366,7 @@ class FlattenedMappings:
         """
         component = self._components[self._display_to_logical[row]]
         # A) Handle two special cases for value mappings
-        if self._is_component_pivoted(row):
+        if self.is_component_pivoted(row):
             # 1. Pivoted data
             return "Pivoted values"
         if self._display_names[row].endswith("values"):

--- a/spine_items/importer/mvcmodels/mappings_model.py
+++ b/spine_items/importer/mvcmodels/mappings_model.py
@@ -20,7 +20,7 @@ import uuid
 from PySide6.QtCore import QAbstractItemModel, QMimeData, QModelIndex, Qt, Signal
 from PySide6.QtGui import QColor, QFont
 from spinedb_api import ParameterValueFormatError, from_database
-from spinedb_api.import_mapping.import_mapping import ScenarioBeforeAlternativeMapping, default_import_mapping
+from spinedb_api.import_mapping.import_mapping import default_import_mapping
 from spinedb_api.import_mapping.import_mapping_compat import (
     import_mapping_from_dict,
     parameter_default_value_mapping_from_dict,
@@ -1304,29 +1304,6 @@ class MappingsModel(QAbstractItemModel):
         flattened_mappings.set_import_entities(import_entities)
         table_index = self.index(table_row, 0)
         list_index = self.index(list_row, 0, table_index)
-        self.dataChanged.emit(list_index, list_index, [Role.FLATTENED_MAPPINGS])
-
-    def set_use_before_alternative(self, table_row, list_row, use_before_alternative):
-        """Sets the use before alternative flag.
-
-        Args:
-            table_row (int): source table row index
-            list_row (int): mapping list row index
-            use_before_alternative (bool): flag value
-        """
-        table_index = self.index(table_row, 0)
-        list_index = self.index(list_row, 0, table_index)
-        mapping_list = self._mappings[table_row].mapping_list[list_row]
-        flattened_mappings = mapping_list.flattened_mappings
-        if use_before_alternative:
-            before_alternative_mapping = ScenarioBeforeAlternativeMapping(Position.hidden)
-            self.beginInsertRows(list_index, 2, 2)
-            flattened_mappings.append_tail_component(before_alternative_mapping)
-            self.endInsertRows()
-        else:
-            self.beginRemoveRows(list_index, 2, 2)
-            flattened_mappings.cut_tail_component()
-            self.endRemoveRows()
         self.dataChanged.emit(list_index, list_index, [Role.FLATTENED_MAPPINGS])
 
     def set_read_start_row(self, table_row, list_row, start_row):

--- a/spine_items/importer/mvcmodels/mappings_model.py
+++ b/spine_items/importer/mvcmodels/mappings_model.py
@@ -403,11 +403,9 @@ class MappingsModel(QAbstractItemModel):
         column = index.column()
         if column == FlattenedColumn.NAME:
             return non_editable
-        if flattened_item.root_mapping.is_pivoted():
-            # special case where we have pivoted data
-            row = index.row()
-            if row > 0 and row == len(flattened_item.display_names) - 1:
-                return non_editable
+        row = index.row()
+        if flattened_item.is_component_pivoted(row):
+            return non_editable
         if column == FlattenedColumn.POSITION:
             component = flattened_item.component_at(index.row())
             if component.value is None and component.position == Position.header:

--- a/spine_items/importer/mvcmodels/source_data_table_model.py
+++ b/spine_items/importer/mvcmodels/source_data_table_model.py
@@ -267,11 +267,17 @@ class SourceDataTableModel(MinimalTableModel):
             QColor: color of index
         """
         row = index.row()
-        column = index.column()
         flattened_mappings = self._mapping_list_index.data(Role.FLATTENED_MAPPINGS)
-        last_row = self._last_row(flattened_mappings)
+        if row < flattened_mappings.root_mapping.read_start_row:
+            return None
+        root_mapping = flattened_mappings.root_mapping
+        row -= root_mapping.read_start_row
+        column = index.column()
+        last_row = root_mapping.last_pivot_row()
         non_pivoted_and_skipped_columns = self._non_pivoted_and_skipped_columns(flattened_mappings)
-        if self.index_below_last_pivot_row(row, column, last_row, flattened_mappings, non_pivoted_and_skipped_columns):
+        if self.index_below_last_pivot_row(
+            row, column, last_row, root_mapping.is_pivoted(), non_pivoted_and_skipped_columns
+        ):
             return flattened_mappings.display_colors[-1]
         for k in range(len(flattened_mappings.display_names)):
             component_mapping = flattened_mappings.component_at(k)
@@ -280,33 +286,20 @@ class SourceDataTableModel(MinimalTableModel):
         return None
 
     @staticmethod
-    def _last_row(flattened_mappings):
-        """Calculates last row when mapping is pivoted.
-
-        Args:
-            flattened_mappings (FlattenedMappings, optional): flattened mappings
-
-        Returns:
-            int: last row
-        """
-        root_mapping = flattened_mappings.root_mapping
-        return max(root_mapping.last_pivot_row(), root_mapping.read_start_row - 1)
-
-    @staticmethod
-    def index_below_last_pivot_row(row, column, last_row, flattened_mappings, non_pivoted_and_skipped_columns):
+    def index_below_last_pivot_row(row, column, last_row, is_pivoted, non_pivoted_and_skipped_columns):
         """Checks if given index is outside pivot.
 
         Args:
             row (int): index row
             column (int): index column
             last_row (int): last non-pivoted row index
-            flattened_mappings (FlattenedMappings): flattened mappings
+            is_pivoted (bool): whether mappings are pivoted
             non_pivoted_and_skipped_columns (set of int): set of column indexes
 
         Returns:
             bool: True if index is below the pivot, False otherwise
         """
-        if not flattened_mappings.root_mapping.is_pivoted():
+        if not is_pivoted:
             return False
         return row > last_row and column not in non_pivoted_and_skipped_columns
 

--- a/spine_items/importer/ui/import_editor_window.py
+++ b/spine_items/importer/ui/import_editor_window.py
@@ -294,20 +294,10 @@ class Ui_MainWindow(object):
 
         self.mapping_options_contents.addWidget(self.ignore_columns_button, 8, 1, 1, 1)
 
-        self.time_series_repeat_check_box = QCheckBox(self.frame_2)
-        self.time_series_repeat_check_box.setObjectName(u"time_series_repeat_check_box")
-
-        self.mapping_options_contents.addWidget(self.time_series_repeat_check_box, 12, 0, 1, 1)
-
         self.import_entity_alternatives_check_box = QCheckBox(self.frame_2)
         self.import_entity_alternatives_check_box.setObjectName(u"import_entity_alternatives_check_box")
 
         self.mapping_options_contents.addWidget(self.import_entity_alternatives_check_box, 9, 0, 1, 1)
-
-        self.map_compression_check_box = QCheckBox(self.frame_2)
-        self.map_compression_check_box.setObjectName(u"map_compression_check_box")
-
-        self.mapping_options_contents.addWidget(self.map_compression_check_box, 12, 1, 1, 1)
 
         self.map_dimension_spin_box = QSpinBox(self.frame_2)
         self.map_dimension_spin_box.setObjectName(u"map_dimension_spin_box")
@@ -338,15 +328,20 @@ class Ui_MainWindow(object):
 
         self.mapping_options_contents.addWidget(self.map_dimensions_label, 5, 0, 1, 1)
 
-        self.before_alternative_check_box = QCheckBox(self.frame_2)
-        self.before_alternative_check_box.setObjectName(u"before_alternative_check_box")
-
-        self.mapping_options_contents.addWidget(self.before_alternative_check_box, 10, 1, 1, 1)
-
         self.import_entities_check_box = QCheckBox(self.frame_2)
         self.import_entities_check_box.setObjectName(u"import_entities_check_box")
 
         self.mapping_options_contents.addWidget(self.import_entities_check_box, 10, 0, 1, 1)
+
+        self.time_series_repeat_check_box = QCheckBox(self.frame_2)
+        self.time_series_repeat_check_box.setObjectName(u"time_series_repeat_check_box")
+
+        self.mapping_options_contents.addWidget(self.time_series_repeat_check_box, 9, 1, 1, 1)
+
+        self.map_compression_check_box = QCheckBox(self.frame_2)
+        self.map_compression_check_box.setObjectName(u"map_compression_check_box")
+
+        self.mapping_options_contents.addWidget(self.map_compression_check_box, 10, 1, 1, 1)
 
 
         self.verticalLayout_3.addLayout(self.mapping_options_contents)
@@ -384,9 +379,7 @@ class Ui_MainWindow(object):
         QWidget.setTabOrder(self.dimension_spin_box, self.map_dimension_spin_box)
         QWidget.setTabOrder(self.map_dimension_spin_box, self.start_read_row_spin_box)
         QWidget.setTabOrder(self.start_read_row_spin_box, self.ignore_columns_button)
-        QWidget.setTabOrder(self.ignore_columns_button, self.time_series_repeat_check_box)
-        QWidget.setTabOrder(self.time_series_repeat_check_box, self.map_compression_check_box)
-        QWidget.setTabOrder(self.map_compression_check_box, self.mapping_spec_table)
+        QWidget.setTabOrder(self.ignore_columns_button, self.mapping_spec_table)
 
         self.retranslateUi(MainWindow)
 
@@ -434,12 +427,7 @@ class Ui_MainWindow(object):
         self.parameter_type_label.setText(QCoreApplication.translate("MainWindow", u"Parameter type:", None))
         self.dimension_label.setText(QCoreApplication.translate("MainWindow", u"Number of dimensions:", None))
         self.ignore_columns_button.setText("")
-#if QT_CONFIG(tooltip)
-        self.time_series_repeat_check_box.setToolTip(QCoreApplication.translate("MainWindow", u"Set the repeat flag for all imported time series", None))
-#endif // QT_CONFIG(tooltip)
-        self.time_series_repeat_check_box.setText(QCoreApplication.translate("MainWindow", u"Repeat time series", None))
         self.import_entity_alternatives_check_box.setText(QCoreApplication.translate("MainWindow", u"Import entity alternatives", None))
-        self.map_compression_check_box.setText(QCoreApplication.translate("MainWindow", u"Compress Maps", None))
 #if QT_CONFIG(tooltip)
         self.map_dimension_spin_box.setToolTip(QCoreApplication.translate("MainWindow", u"Number of dimensions when value type is Map.", None))
 #endif // QT_CONFIG(tooltip)
@@ -450,10 +438,11 @@ class Ui_MainWindow(object):
         self.read_start_row_label.setText(QCoreApplication.translate("MainWindow", u"Read data from row:", None))
         self.ignore_columns_label.setText(QCoreApplication.translate("MainWindow", u"Ignore columns:", None))
         self.map_dimensions_label.setText(QCoreApplication.translate("MainWindow", u"Map dimensions:", None))
-#if QT_CONFIG(tooltip)
-        self.before_alternative_check_box.setToolTip(QCoreApplication.translate("MainWindow", u"Enable or disable 'Before alternative name' mapping for scenario alternative item type.", None))
-#endif // QT_CONFIG(tooltip)
-        self.before_alternative_check_box.setText(QCoreApplication.translate("MainWindow", u"Use before alternative", None))
         self.import_entities_check_box.setText(QCoreApplication.translate("MainWindow", u"Import entities", None))
+#if QT_CONFIG(tooltip)
+        self.time_series_repeat_check_box.setToolTip(QCoreApplication.translate("MainWindow", u"Set the repeat flag for all imported time series", None))
+#endif // QT_CONFIG(tooltip)
+        self.time_series_repeat_check_box.setText(QCoreApplication.translate("MainWindow", u"Repeat time series", None))
+        self.map_compression_check_box.setText(QCoreApplication.translate("MainWindow", u"Compress Maps", None))
     # retranslateUi
 

--- a/spine_items/importer/ui/import_editor_window.ui
+++ b/spine_items/importer/ui/import_editor_window.ui
@@ -464,27 +464,10 @@
                 </property>
                </widget>
               </item>
-              <item row="12" column="0">
-               <widget class="QCheckBox" name="time_series_repeat_check_box">
-                <property name="toolTip">
-                 <string>Set the repeat flag for all imported time series</string>
-                </property>
-                <property name="text">
-                 <string>Repeat time series</string>
-                </property>
-               </widget>
-              </item>
               <item row="9" column="0">
                <widget class="QCheckBox" name="import_entity_alternatives_check_box">
                 <property name="text">
                  <string>Import entity alternatives</string>
-                </property>
-               </widget>
-              </item>
-              <item row="12" column="1">
-               <widget class="QCheckBox" name="map_compression_check_box">
-                <property name="text">
-                 <string>Compress Maps</string>
                 </property>
                </widget>
               </item>
@@ -538,20 +521,27 @@
                 </property>
                </widget>
               </item>
-              <item row="10" column="1">
-               <widget class="QCheckBox" name="before_alternative_check_box">
-                <property name="toolTip">
-                 <string>Enable or disable 'Before alternative name' mapping for scenario alternative item type.</string>
-                </property>
-                <property name="text">
-                 <string>Use before alternative</string>
-                </property>
-               </widget>
-              </item>
               <item row="10" column="0">
                <widget class="QCheckBox" name="import_entities_check_box">
                 <property name="text">
                  <string>Import entities</string>
+                </property>
+               </widget>
+              </item>
+              <item row="9" column="1">
+               <widget class="QCheckBox" name="time_series_repeat_check_box">
+                <property name="toolTip">
+                 <string>Set the repeat flag for all imported time series</string>
+                </property>
+                <property name="text">
+                 <string>Repeat time series</string>
+                </property>
+               </widget>
+              </item>
+              <item row="10" column="1">
+               <widget class="QCheckBox" name="map_compression_check_box">
+                <property name="text">
+                 <string>Compress Maps</string>
                 </property>
                </widget>
               </item>
@@ -632,8 +622,6 @@
   <tabstop>map_dimension_spin_box</tabstop>
   <tabstop>start_read_row_spin_box</tabstop>
   <tabstop>ignore_columns_button</tabstop>
-  <tabstop>time_series_repeat_check_box</tabstop>
-  <tabstop>map_compression_check_box</tabstop>
   <tabstop>mapping_spec_table</tabstop>
  </tabstops>
  <resources>

--- a/spine_items/importer/widgets/import_mapping_options.py
+++ b/spine_items/importer/widgets/import_mapping_options.py
@@ -23,7 +23,6 @@ from ..commands import (
     SetReadStartRow,
     SetSkipColumns,
     SetTimeSeriesRepeatFlag,
-    SetUseBeforeAlternativeFlag,
     SetValueType,
 )
 from ..flattened_mappings import MappingType
@@ -59,7 +58,6 @@ class ImportMappingOptions:
         self._ui.class_type_combo_box.currentTextChanged.connect(self._change_item_mapping_type)
         self._ui.parameter_type_combo_box.currentTextChanged.connect(self._change_parameter_type)
         self._ui.value_type_combo_box.currentTextChanged.connect(self._change_value_type)
-        self._ui.before_alternative_check_box.stateChanged.connect(self._change_use_before_alternative)
         self._ui.import_entities_check_box.stateChanged.connect(self._change_import_entities)
         self._ui_ignore_columns_filtermenu.filterChanged.connect(self._change_skip_columns)
         self._ui.start_read_row_spin_box.valueChanged.connect(self._change_read_start_row)
@@ -183,12 +181,6 @@ class ImportMappingOptions:
             self._ui.value_type_combo_box.setCurrentText(flattened_mappings.value_type)
             self._ui.value_type_label.setText(flattened_mappings.value_type_label())
 
-        # update before alternative settings
-        is_scenario_alternative_mapping = flattened_mappings.map_type == MappingType.ScenarioAlternative
-        self._ui.before_alternative_check_box.setEnabled(is_scenario_alternative_mapping)
-        if is_scenario_alternative_mapping:
-            self._ui.before_alternative_check_box.setChecked(flattened_mappings.uses_before_alternative())
-
         # update ignore columns filter
         self._ui.ignore_columns_button.setEnabled(flattened_mappings.root_mapping.is_pivoted())
         self._ui.ignore_columns_label.setEnabled(flattened_mappings.root_mapping.is_pivoted())
@@ -291,27 +283,6 @@ class ImportMappingOptions:
         self._undo_stack.push(
             SetValueType(
                 self._list_index.parent().row(), self._list_index.row(), self._mappings_model, new_type, old_type
-            )
-        )
-
-    @Slot(int)
-    def _change_use_before_alternative(self, state):
-        """
-        Pushes SetUseBeforeAlternative command to the undo stack.
-
-        Args:
-            state (int): New state value
-        """
-        if self._block_signals or not self._has_current_mappings():
-            return
-        previous_mapping = self._list_index.data(Role.FLATTENED_MAPPINGS).root_mapping
-        self._undo_stack.push(
-            SetUseBeforeAlternativeFlag(
-                self._list_index.parent().row(),
-                self._list_index.row(),
-                self._mappings_model,
-                state == Qt.CheckState.Checked.value,
-                previous_mapping,
             )
         )
 

--- a/tests/importer/mvcmodels/test_mappings_model.py
+++ b/tests/importer/mvcmodels/test_mappings_model.py
@@ -719,7 +719,7 @@ class TestMappingComponentsTable(unittest.TestCase):
         index = self._model.index(6, 1, self._list_index)
         self.assertEqual(index.data(), "None")
         index = self._model.index(7, 1, self._list_index)
-        self.assertEqual(index.data(), "Pivoted")
+        self.assertEqual(index.data(), "Row")
         index = self._model.index(0, 2, self._list_index)
         self.assertEqual(index.data(), 0 + 1)
         self.assertEqual(index.data(Qt.ItemDataRole.BackgroundRole), None)
@@ -749,7 +749,7 @@ class TestMappingComponentsTable(unittest.TestCase):
         self.assertEqual(index.data(Qt.ItemDataRole.BackgroundRole), None)
         self.assertFalse(index.data(Qt.ItemDataRole.ToolTipRole))
         index = self._model.index(7, 2, self._list_index)
-        self.assertEqual(index.data(), "Pivoted values")
+        self.assertEqual(index.data(), 1)
         self.assertEqual(index.data(Qt.ItemDataRole.BackgroundRole), None)
         self.assertFalse(index.data(Qt.ItemDataRole.ToolTipRole))
         for row in range(8):

--- a/tests/importer/test_flattened_mappings.py
+++ b/tests/importer/test_flattened_mappings.py
@@ -50,7 +50,6 @@ class TestFlattenedMappings(unittest.TestCase):
         self.assertFalse(flattened_mappings.is_time_series_value())
         self.assertFalse(flattened_mappings.is_map_value())
         self.assertEqual(flattened_mappings.map_dimension_count(), 1)
-        self.assertFalse(flattened_mappings.uses_before_alternative())
         self.assertEqual(flattened_mappings.read_start_row(), 0)
         self.assertEqual(flattened_mappings.skip_columns(), [])
         for row in range(len(flattened_mappings.display_names)):


### PR DESCRIPTION
This PR fixes minor issues in Importer:
- If the last mapping component is positioned on Row (or header), we do not mark the component as "Pivoted" because it prevents modifying the component anymore.
- Removed the option to enable "before alternative" scenario alternative mappings, also from Exporter. Practically no-one uses this pretty esoteric mapping
- Fix some cases where the Source table colors were off.

Re spine-tools/Spine-Toolbox#2962

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
