### PR TITLE
Make sqlite readily selected in empty Data store properties

### DIFF
--- a/spine_items/data_store/commands.py
+++ b/spine_items/data_store/commands.py
@@ -51,6 +51,7 @@ class UpdateDSURLCommand(SpineToolboxCommand):
             not isinstance(command, UpdateDSURLCommand)
             or self._ds_name != command._ds_name
             or command._undo_url_is_valid
+            or set(self._redo_kwargs.keys()).isdisjoint(command._redo_kwargs.keys())
         ):
             return False
         diff_key = None

--- a/spine_items/data_store/widgets/data_store_properties_widget.py
+++ b/spine_items/data_store/widgets/data_store_properties_widget.py
@@ -29,9 +29,8 @@ class DataStorePropertiesWidget(PropertiesWidgetBase):
         self._active_item = None
         self.ui = Ui_Form()
         self.ui.setupUi(self)
-        self.ui.url_selector_widget.setup(
-            list(SUPPORTED_DIALECTS.keys()), self._select_sqlite_file, True, self._toolbox
-        )
+        dialects = ["sqlite"] + list(filter(lambda d: d != "sqlite", SUPPORTED_DIALECTS.keys()))
+        self.ui.url_selector_widget.setup(dialects, self._select_sqlite_file, True, self._toolbox)
 
     def _select_sqlite_file(self):
         """Lets active item select an SQLite file.

--- a/spine_items/data_store/widgets/data_store_properties_widget.py
+++ b/spine_items/data_store/widgets/data_store_properties_widget.py
@@ -13,10 +13,9 @@
 """Data store properties widget."""
 from spinedb_api import SUPPORTED_DIALECTS
 from spinetoolbox.widgets.properties_widget import PropertiesWidgetBase
-from ...widgets import UrlSelectorMixin
 
 
-class DataStorePropertiesWidget(UrlSelectorMixin, PropertiesWidgetBase):
+class DataStorePropertiesWidget(PropertiesWidgetBase):
     """Widget for the Data Store Item Properties."""
 
     def __init__(self, toolbox):
@@ -33,18 +32,6 @@ class DataStorePropertiesWidget(UrlSelectorMixin, PropertiesWidgetBase):
         self.ui.url_selector_widget.setup(
             list(SUPPORTED_DIALECTS.keys()), self._select_sqlite_file, True, self._toolbox
         )
-
-    def set_item(self, project_item):
-        """Sets the active project item for the properties widget.
-
-        Args:
-            project_item (DataStore): data store
-        """
-        self._active_item = project_item
-
-    def unset_item(self):
-        """Unsets the active item."""
-        self._active_item = None
 
     def _select_sqlite_file(self):
         """Lets active item select an SQLite file.

--- a/spine_items/widgets.py
+++ b/spine_items/widgets.py
@@ -327,8 +327,8 @@ class UrlSelectorWidget(QWidget):
         username = url.get("username", "")
         password = url.get("password", "")
         self.blockSignals(True)
-        if dialect == "":
-            self._ui.comboBox_dialect.setCurrentIndex(-1)
+        if not dialect:
+            self._ui.comboBox_dialect.setCurrentIndex(-1 if self._ui.comboBox_dialect.count() == 0 else 0)
         elif dialect != self._ui.comboBox_dialect.currentText():
             self._ui.comboBox_dialect.setCurrentText(dialect)
         _set_line_edit_text(self._ui.lineEdit_host, host)

--- a/spine_items/widgets.py
+++ b/spine_items/widgets.py
@@ -250,92 +250,6 @@ class FileDropTargetLineEdit(QLineEdit):
         self.setText(url.toLocalFile())
 
 
-KNOWN_SQL_DIALECTS = ("mysql", "sqlite", "mssql", "postgresql")
-
-
-class UrlSelectorMixin:
-    def _setup(self, dialects):
-        self.ui.comboBox_dialect.addItems(dialects)
-        self.ui.comboBox_dialect.setCurrentIndex(-1)
-        self.ui.lineEdit_port.setValidator(QIntValidator())
-
-    def enable_dialect(self, dialect):
-        """Enables the given dialect in the item controls."""
-        if dialect == "":
-            self.enable_no_dialect()
-        elif dialect == "sqlite":
-            self.enable_sqlite()
-        elif dialect == "mssql":
-            import pyodbc  # pylint: disable=import-outside-toplevel
-
-            dsns = pyodbc.dataSources()
-            # Collect dsns which use the msodbcsql driver
-            mssql_dsns = []
-            for key, value in dsns.items():
-                if "msodbcsql" in value.lower():
-                    mssql_dsns.append(key)
-            if mssql_dsns:
-                self.ui.comboBox_dsn.clear()
-                self.ui.comboBox_dsn.addItems(mssql_dsns)
-                self.ui.comboBox_dsn.setCurrentIndex(-1)
-                self.enable_mssql()
-            else:
-                msg = "Please create an SQL Server ODBC Data Source first."
-                self._toolbox.msg_warning.emit(msg)
-        else:
-            self.enable_common()
-
-    def enable_no_dialect(self):
-        """Adjusts widget enabled status to default when no dialect is selected."""
-        self.ui.comboBox_dialect.setEnabled(True)
-        self.ui.comboBox_dsn.setEnabled(False)
-        self.ui.toolButton_select_sqlite_file.setEnabled(False)
-        self.ui.lineEdit_host.setEnabled(False)
-        self.ui.lineEdit_port.setEnabled(False)
-        self.ui.lineEdit_database.setEnabled(False)
-        self.ui.lineEdit_username.setEnabled(False)
-        self.ui.lineEdit_password.setEnabled(False)
-
-    def enable_mssql(self):
-        """Adjusts controls to mssql connection specification."""
-        self.ui.comboBox_dsn.setEnabled(True)
-        self.ui.toolButton_select_sqlite_file.setEnabled(False)
-        self.ui.lineEdit_host.setEnabled(False)
-        self.ui.lineEdit_port.setEnabled(False)
-        self.ui.lineEdit_database.setEnabled(False)
-        self.ui.lineEdit_username.setEnabled(True)
-        self.ui.lineEdit_password.setEnabled(True)
-        self.ui.lineEdit_host.clear()
-        self.ui.lineEdit_port.clear()
-        self.ui.lineEdit_database.clear()
-
-    def enable_sqlite(self):
-        """Adjusts controls to sqlite connection specification."""
-        self.ui.comboBox_dsn.setEnabled(False)
-        self.ui.comboBox_dsn.setCurrentIndex(-1)
-        self.ui.toolButton_select_sqlite_file.setEnabled(True)
-        self.ui.lineEdit_host.setEnabled(False)
-        self.ui.lineEdit_port.setEnabled(False)
-        self.ui.lineEdit_database.setEnabled(True)
-        self.ui.lineEdit_username.setEnabled(False)
-        self.ui.lineEdit_password.setEnabled(False)
-        self.ui.lineEdit_host.clear()
-        self.ui.lineEdit_port.clear()
-        self.ui.lineEdit_username.clear()
-        self.ui.lineEdit_password.clear()
-
-    def enable_common(self):
-        """Adjusts controls to 'common' connection specification."""
-        self.ui.comboBox_dsn.setEnabled(False)
-        self.ui.comboBox_dsn.setCurrentIndex(-1)
-        self.ui.toolButton_select_sqlite_file.setEnabled(False)
-        self.ui.lineEdit_host.setEnabled(True)
-        self.ui.lineEdit_port.setEnabled(True)
-        self.ui.lineEdit_database.setEnabled(True)
-        self.ui.lineEdit_username.setEnabled(True)
-        self.ui.lineEdit_password.setEnabled(True)
-
-
 def _set_line_edit_text(edit, text):
     """Sets QLineEdit's text only if it is changing.
 
@@ -348,6 +262,9 @@ def _set_line_edit_text(edit, text):
     """
     if text != edit.text():
         edit.setText(text)
+
+
+KNOWN_SQL_DIALECTS = ("mysql", "sqlite", "mssql", "postgresql")
 
 
 class UrlSelectorWidget(QWidget):

--- a/tests/data_store/test_commands.py
+++ b/tests/data_store/test_commands.py
@@ -1,0 +1,42 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Items contributors
+# This file is part of Spine Items.
+# Spine Items is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+import unittest
+from unittest import mock
+from spine_items.data_store.commands import UpdateDSURLCommand
+
+
+class TestUpdateDSURLCommand(unittest.TestCase):
+    def test_merging_with_command_that_modifies_same_fields_works(self):
+        mock_ds = mock.MagicMock()
+        mock_ds.url.return_value = {"username": "c"}
+        mock_project = mock.MagicMock()
+        mock_project.get_item.return_value = mock_ds
+        command1 = UpdateDSURLCommand("DS 1", False, mock_project, username="ca")
+        mock_ds.url.return_value = {"username": "ca"}
+        command2 = UpdateDSURLCommand("DS 1", False, mock_project, username="cat")
+        self.assertTrue(command1.mergeWith(command2))
+        command1.redo()
+        mock_ds.do_update_url.assert_called_once_with(username="cat")
+
+    def test_merging_is_rejected_when_commands_modify_different_fields(self):
+        mock_ds = mock.MagicMock()
+        mock_ds.url.return_value = {"username": "c", "host": ""}
+        mock_project = mock.MagicMock()
+        mock_project.get_item.return_value = mock_ds
+        command1 = UpdateDSURLCommand("DS 1", False, mock_project, username="ca")
+        mock_ds.url.return_value = {"username": "ca", "host": ""}
+        command2 = UpdateDSURLCommand("DS 1", False, mock_project, host="q")
+        self.assertFalse(command1.mergeWith(command2))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/data_store/test_dataStore.py
+++ b/tests/data_store/test_dataStore.py
@@ -214,13 +214,13 @@ class TestDataStoreWithMockToolbox(unittest.TestCase):
         """
         self.ds.activate()
         url = self.ds_properties_ui.url_selector_widget.url_dict()
-        self.assertEqual(url["dialect"], "")
+        self.assertEqual(url["dialect"], "sqlite")
         self.assertEqual(url["database"], "")
         # Click New Spine db button
         self.toolbox.db_mngr = mock.MagicMock()
         self.ds_properties_ui.pushButton_create_new_spine_db.click()
         url = self.ds_properties_ui.url_selector_widget.url_dict()
-        self.assertEqual(url["dialect"], "")
+        self.assertEqual(url["dialect"], "sqlite")
         self.assertEqual(url["database"], "")
         self.toolbox.db_mngr.create_new_spine_database.assert_not_called()
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,0 +1,36 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Items contributors
+# This file is part of Spine Items.
+# Spine Items is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+import unittest
+from unittest import mock
+from PySide6.QtWidgets import QApplication
+from spine_items.widgets import UrlSelectorWidget
+from tests.mock_helpers import parent_widget
+
+
+class TestUrlSelectorWidget(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not QApplication.instance():
+            QApplication()
+
+    def test_first_dialect_is_selected_in_combo_box(self):
+        with parent_widget() as parent:
+            widget = UrlSelectorWidget(parent)
+            callback = mock.MagicMock()
+            logger = mock.MagicMock()
+            widget.setup(["dialect 1", "dialect 2"], callback, False, logger)
+            widget.set_url({})
+            self.assertEqual(widget._ui.comboBox_dialect.currentIndex(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
sqlite is by far the number one choice.

Also fixed some bugs in undo action and the URL widget.

Implements spine-tools/Spine-Toolbox#2968

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
