### PR TITLE
Use the new DB editor facilities in Toolbox

### DIFF
--- a/spine_items/utils.py
+++ b/spine_items/utils.py
@@ -84,7 +84,7 @@ def _convert_url(url):
         if dialect == "sqlite":
             database = url.get("database", "")
             if database:
-                url["database"] = os.path.abspath(database)
+                url["database"] = os.path.normcase(os.path.abspath(database))
             return URL("sqlite", **url)  # pylint: disable=unexpected-keyword-arg
         db_api = spinedb_api.SUPPORTED_DIALECTS.get(dialect)
         if db_api is None:

--- a/tests/data_store/test_DataStoreExecutable.py
+++ b/tests/data_store/test_DataStoreExecutable.py
@@ -12,6 +12,7 @@
 
 """Unit tests for DataStoreExecutable."""
 from multiprocessing import Lock
+import os.path
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
@@ -82,7 +83,7 @@ class TestDataStoreExecutable(unittest.TestCase):
         self.assertEqual(len(resources), 1)
         resource = resources[0]
         self.assertEqual(resource.type_, "database")
-        self.assertEqual(resource.url, "sqlite:///" + str(db_file_path))
+        self.assertEqual(resource.url, "sqlite:///" + os.path.normcase(str(db_file_path)))
         self.assertEqual(resource.label, "db_url@name")
 
     def test_output_resources_forward(self):
@@ -95,7 +96,7 @@ class TestDataStoreExecutable(unittest.TestCase):
         self.assertEqual(len(resources), 1)
         resource = resources[0]
         self.assertEqual(resource.type_, "database")
-        self.assertEqual(resource.url, "sqlite:///" + str(db_file_path))
+        self.assertEqual(resource.url, "sqlite:///" + os.path.normcase(str(db_file_path)))
         self.assertEqual(resource.label, "db_url@name")
 
 

--- a/tests/exporter/test_utils.py
+++ b/tests/exporter/test_utils.py
@@ -28,7 +28,7 @@ class TestOutputDatabaseResources(unittest.TestCase):
             ),
         ]
         resources = output_database_resources(item_name, channels)
-        expected_url = "sqlite:///" + os.path.abspath("/path/to/db.sqlite")
+        expected_url = "sqlite:///" + os.path.normcase(os.path.abspath("/path/to/db.sqlite"))
         self.assertEqual(resources, [url_resource(item_name, expected_url, "out database")])
 
 

--- a/tests/merger/test_MergerExecutable.py
+++ b/tests/merger/test_MergerExecutable.py
@@ -12,6 +12,7 @@
 
 """Unit tests for MergerExecutable."""
 from multiprocessing import Lock
+import os.path
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
@@ -98,20 +99,20 @@ class TestMergerExecutable(unittest.TestCase):
 
     def test_write_order(self):
         db1_path = Path(self._temp_dir.name, "db1.sqlite")
-        db1_url = "sqlite:///" + str(db1_path)
+        db1_url = "sqlite:///" + os.path.normcase(str(db1_path))
         # Add some data to db1
         with DatabaseMapping(db1_url, create=True) as db1_map:
             import_functions.import_data(db1_map, entity_classes=[("fish",)])
             db1_map.commit_session("Add test data.")
         db2_path = Path(self._temp_dir.name, "db2.sqlite")
-        db2_url = "sqlite:///" + str(db2_path)
+        db2_url = "sqlite:///" + os.path.normcase(str(db2_path))
         # Add some data to db2
         with DatabaseMapping(db2_url, create=True) as db2_map:
             import_functions.import_data(db2_map, entity_classes=[("cat",)])
             db2_map.commit_session("Add test data.")
         # Make an empty output db
         db3_path = Path(self._temp_dir.name, "db3.sqlite")
-        db3_url = "sqlite:///" + str(db3_path)
+        db3_url = "sqlite:///" + os.path.normcase(str(db3_path))
         # Make two mergers
         logger = mock.MagicMock()
         logger.__reduce__ = lambda _: (mock.MagicMock, ())


### PR DESCRIPTION
Data stores are no longer responsible of Database editor's tab names. They merely register their names as candidates for database display names but it is up to Toolbox what it chooses to do with the information. This simplifies code and responsibilities in `spine_items`.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
