### PR TITLE
Fix random segfault when adding source files to Tool specification editor

### DIFF
--- a/spine_items/tool/widgets/tool_specification_editor_window.py
+++ b/spine_items/tool/widgets/tool_specification_editor_window.py
@@ -830,7 +830,8 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
 
     def _clear_program_text_edit(self):
         """Clears contents of the text editor."""
-        self._ui.textEdit_program.setDocument(None)
+        empty_doc = QTextDocument(self._ui.textEdit_program)
+        self._ui.textEdit_program.setDocument(empty_doc)
         self._ui.textEdit_program.setEnabled(False)
         self._ui.textEdit_program.file_selected(False)
         self._ui.dockWidget_program.setWindowTitle("No file selected")


### PR DESCRIPTION
Fixes spine-tools/Spine-Toolbox#3006

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
