### PR TITLE
Add QScrollAreas to Project Item Properties widgets

### DIFF
--- a/spine_items/data_connection/ui/data_connection_properties.py
+++ b/spine_items/data_connection/ui/data_connection_properties.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'data_connection_properties.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.5.2
+## Created by: Qt User Interface Compiler version 6.7.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -28,8 +28,8 @@ from PySide6.QtGui import (QAction, QBrush, QColor, QConicalGradient,
     QPainter, QPalette, QPixmap, QRadialGradient,
     QTransform)
 from PySide6.QtWidgets import (QAbstractItemView, QApplication, QHBoxLayout, QHeaderView,
-    QSizePolicy, QSpacerItem, QToolButton, QVBoxLayout,
-    QWidget)
+    QScrollArea, QSizePolicy, QSpacerItem, QToolButton,
+    QVBoxLayout, QWidget)
 
 from spine_items.widgets import (DataTreeView, ReferencesTreeView)
 from spine_items import resources_icons_rc
@@ -42,75 +42,91 @@ class Ui_Form(object):
         self.action_new_file_reference = QAction(Form)
         self.action_new_file_reference.setObjectName(u"action_new_file_reference")
         icon = QIcon()
-        icon.addFile(u":/icons/plus.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon.addFile(u":/icons/plus.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.action_new_file_reference.setIcon(icon)
         self.action_new_db_reference = QAction(Form)
         self.action_new_db_reference.setObjectName(u"action_new_db_reference")
         self.action_new_db_reference.setIcon(icon)
-        self.verticalLayout = QVBoxLayout(Form)
+        self.verticalLayout_2 = QVBoxLayout(Form)
+        self.verticalLayout_2.setSpacing(0)
+        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.verticalLayout_2.setContentsMargins(0, 0, 0, 0)
+        self.scrollArea = QScrollArea(Form)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 272, 436))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout.setSpacing(0)
         self.verticalLayout.setObjectName(u"verticalLayout")
-        self.treeView_dc_references = ReferencesTreeView(Form)
+        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
+        self.treeView_dc_references = ReferencesTreeView(self.scrollAreaWidgetContents)
         self.treeView_dc_references.setObjectName(u"treeView_dc_references")
-        sizePolicy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.treeView_dc_references.sizePolicy().hasHeightForWidth())
         self.treeView_dc_references.setSizePolicy(sizePolicy)
-        self.treeView_dc_references.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.treeView_dc_references.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.treeView_dc_references.setAcceptDrops(True)
-        self.treeView_dc_references.setSelectionMode(QAbstractItemView.ExtendedSelection)
-        self.treeView_dc_references.setTextElideMode(Qt.ElideLeft)
-        self.treeView_dc_references.setVerticalScrollMode(QAbstractItemView.ScrollPerPixel)
+        self.treeView_dc_references.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.treeView_dc_references.setTextElideMode(Qt.TextElideMode.ElideLeft)
+        self.treeView_dc_references.setVerticalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
         self.treeView_dc_references.header().setStretchLastSection(True)
 
         self.verticalLayout.addWidget(self.treeView_dc_references)
 
         self.horizontalLayout_2 = QHBoxLayout()
         self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
-        self.toolButton_add = QToolButton(Form)
+        self.toolButton_add = QToolButton(self.scrollAreaWidgetContents)
         self.toolButton_add.setObjectName(u"toolButton_add")
         icon1 = QIcon()
-        icon1.addFile(u":/icons/file-download.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon1.addFile(u":/icons/file-download.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.toolButton_add.setIcon(icon1)
-        self.toolButton_add.setPopupMode(QToolButton.InstantPopup)
+        self.toolButton_add.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
 
         self.horizontalLayout_2.addWidget(self.toolButton_add)
 
-        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.horizontalLayout_2.addItem(self.horizontalSpacer_2)
 
-        self.toolButton_minus = QToolButton(Form)
+        self.toolButton_minus = QToolButton(self.scrollAreaWidgetContents)
         self.toolButton_minus.setObjectName(u"toolButton_minus")
-        sizePolicy1 = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        sizePolicy1 = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
         sizePolicy1.setHeightForWidth(self.toolButton_minus.sizePolicy().hasHeightForWidth())
         self.toolButton_minus.setSizePolicy(sizePolicy1)
         icon2 = QIcon()
-        icon2.addFile(u":/icons/minus.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon2.addFile(u":/icons/minus.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.toolButton_minus.setIcon(icon2)
-        self.toolButton_minus.setPopupMode(QToolButton.InstantPopup)
+        self.toolButton_minus.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
 
         self.horizontalLayout_2.addWidget(self.toolButton_minus)
 
 
         self.verticalLayout.addLayout(self.horizontalLayout_2)
 
-        self.treeView_dc_data = DataTreeView(Form)
+        self.treeView_dc_data = DataTreeView(self.scrollAreaWidgetContents)
         self.treeView_dc_data.setObjectName(u"treeView_dc_data")
         sizePolicy.setHeightForWidth(self.treeView_dc_data.sizePolicy().hasHeightForWidth())
         self.treeView_dc_data.setSizePolicy(sizePolicy)
-        self.treeView_dc_data.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.treeView_dc_data.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.treeView_dc_data.setAcceptDrops(True)
-        self.treeView_dc_data.setSelectionMode(QAbstractItemView.ExtendedSelection)
-        self.treeView_dc_data.setTextElideMode(Qt.ElideLeft)
-        self.treeView_dc_data.setVerticalScrollMode(QAbstractItemView.ScrollPerPixel)
+        self.treeView_dc_data.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.treeView_dc_data.setTextElideMode(Qt.TextElideMode.ElideLeft)
+        self.treeView_dc_data.setVerticalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
         self.treeView_dc_data.setIndentation(5)
         self.treeView_dc_data.setUniformRowHeights(True)
         self.treeView_dc_data.header().setStretchLastSection(True)
 
         self.verticalLayout.addWidget(self.treeView_dc_data)
+
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.verticalLayout_2.addWidget(self.scrollArea)
 
 
         self.retranslateUi(Form)

--- a/spine_items/data_connection/ui/data_connection_properties.ui
+++ b/spine_items/data_connection/ui/data_connection_properties.ui
@@ -2,6 +2,7 @@
 <!--
 ######################################################################################################################
 # Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Items contributors
 # This file is part of Spine Items.
 # Spine Items is free software: you can redistribute it and\/or modify it under the terms of the GNU Lesser General
 # Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
@@ -25,130 +26,179 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <widget class="ReferencesTreeView" name="treeView_dc_references">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="contextMenuPolicy">
-      <enum>Qt::CustomContextMenu</enum>
-     </property>
-     <property name="acceptDrops">
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
       <bool>true</bool>
      </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Drag-and-drop files here, they will be added as references.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="textElideMode">
-      <enum>Qt::ElideLeft</enum>
-     </property>
-     <property name="verticalScrollMode">
-      <enum>QAbstractItemView::ScrollPerPixel</enum>
-     </property>
-     <attribute name="headerStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QToolButton" name="toolButton_add">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy selected file references to this Data Connection's directory&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>272</width>
+        <height>436</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="spacing">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string/>
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="icon">
-        <iconset resource="../../ui/resources/resources_icons.qrc">
-         <normaloff>:/icons/file-download.svg</normaloff>:/icons/file-download.svg</iconset>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-       <property name="popupMode">
-        <enum>QToolButton::InstantPopup</enum>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QToolButton" name="toolButton_minus">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove selected references&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../../ui/resources/resources_icons.qrc">
-         <normaloff>:/icons/minus.svg</normaloff>:/icons/minus.svg</iconset>
-       </property>
-       <property name="popupMode">
-        <enum>QToolButton::InstantPopup</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="DataTreeView" name="treeView_dc_data">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="contextMenuPolicy">
-      <enum>Qt::CustomContextMenu</enum>
-     </property>
-     <property name="acceptDrops">
-      <bool>true</bool>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Drag-and-drop files here, they will be copied to the data directory.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="textElideMode">
-      <enum>Qt::ElideLeft</enum>
-     </property>
-     <property name="verticalScrollMode">
-      <enum>QAbstractItemView::ScrollPerPixel</enum>
-     </property>
-     <property name="indentation">
-      <number>5</number>
-     </property>
-     <property name="uniformRowHeights">
-      <bool>true</bool>
-     </property>
-     <attribute name="headerStretchLastSection">
-      <bool>true</bool>
-     </attribute>
+       <item>
+        <widget class="ReferencesTreeView" name="treeView_dc_references">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
+         </property>
+         <property name="acceptDrops">
+          <bool>true</bool>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Drag-and-drop files here, they will be added as references.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+         </property>
+         <property name="textElideMode">
+          <enum>Qt::TextElideMode::ElideLeft</enum>
+         </property>
+         <property name="verticalScrollMode">
+          <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
+         </property>
+         <attribute name="headerStretchLastSection">
+          <bool>true</bool>
+         </attribute>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QToolButton" name="toolButton_add">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy selected file references to this Data Connection's directory&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../ui/resources/resources_icons.qrc">
+             <normaloff>:/icons/file-download.svg</normaloff>:/icons/file-download.svg</iconset>
+           </property>
+           <property name="popupMode">
+            <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QToolButton" name="toolButton_minus">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove selected references&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../ui/resources/resources_icons.qrc">
+             <normaloff>:/icons/minus.svg</normaloff>:/icons/minus.svg</iconset>
+           </property>
+           <property name="popupMode">
+            <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="DataTreeView" name="treeView_dc_data">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
+         </property>
+         <property name="acceptDrops">
+          <bool>true</bool>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Drag-and-drop files here, they will be copied to the data directory.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+         </property>
+         <property name="textElideMode">
+          <enum>Qt::TextElideMode::ElideLeft</enum>
+         </property>
+         <property name="verticalScrollMode">
+          <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
+         </property>
+         <property name="indentation">
+          <number>5</number>
+         </property>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
+         </property>
+         <attribute name="headerStretchLastSection">
+          <bool>true</bool>
+         </attribute>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/spine_items/data_store/ui/data_store_properties.py
+++ b/spine_items/data_store/ui/data_store_properties.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'data_store_properties.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.5.2
+## Created by: Qt User Interface Compiler version 6.7.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -27,7 +27,8 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QApplication, QGroupBox, QHBoxLayout, QPushButton,
-    QSizePolicy, QSpacerItem, QVBoxLayout, QWidget)
+    QScrollArea, QSizePolicy, QSpacerItem, QVBoxLayout,
+    QWidget)
 
 from spine_items.widgets import UrlSelectorWidget
 from spine_items import resources_icons_rc
@@ -37,9 +38,21 @@ class Ui_Form(object):
         if not Form.objectName():
             Form.setObjectName(u"Form")
         Form.resize(369, 337)
-        self.verticalLayout = QVBoxLayout(Form)
+        self.verticalLayout_3 = QVBoxLayout(Form)
+        self.verticalLayout_3.setSpacing(0)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
+        self.verticalLayout_3.setContentsMargins(0, 0, 0, 0)
+        self.scrollArea = QScrollArea(Form)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 367, 335))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout.setSpacing(0)
         self.verticalLayout.setObjectName(u"verticalLayout")
-        self.groupBox = QGroupBox(Form)
+        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
+        self.groupBox = QGroupBox(self.scrollAreaWidgetContents)
         self.groupBox.setObjectName(u"groupBox")
         self.verticalLayout_2 = QVBoxLayout(self.groupBox)
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
@@ -54,35 +67,35 @@ class Ui_Form(object):
 
         self.horizontalLayout_3 = QHBoxLayout()
         self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
-        self.purge_button = QPushButton(Form)
+        self.purge_button = QPushButton(self.scrollAreaWidgetContents)
         self.purge_button.setObjectName(u"purge_button")
-        sizePolicy = QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.purge_button.sizePolicy().hasHeightForWidth())
         self.purge_button.setSizePolicy(sizePolicy)
         icon = QIcon()
-        icon.addFile(u":/icons/bolt-lightning.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon.addFile(u":/icons/bolt-lightning.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.purge_button.setIcon(icon)
 
         self.horizontalLayout_3.addWidget(self.purge_button)
 
-        self.toolButton_vacuum = QPushButton(Form)
+        self.toolButton_vacuum = QPushButton(self.scrollAreaWidgetContents)
         self.toolButton_vacuum.setObjectName(u"toolButton_vacuum")
         icon1 = QIcon()
-        icon1.addFile(u":/icons/broom.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon1.addFile(u":/icons/broom.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.toolButton_vacuum.setIcon(icon1)
 
         self.horizontalLayout_3.addWidget(self.toolButton_vacuum)
 
-        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.horizontalLayout_3.addItem(self.horizontalSpacer_3)
 
-        self.toolButton_copy_url = QPushButton(Form)
+        self.toolButton_copy_url = QPushButton(self.scrollAreaWidgetContents)
         self.toolButton_copy_url.setObjectName(u"toolButton_copy_url")
         icon2 = QIcon()
-        icon2.addFile(u":/icons/copy.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon2.addFile(u":/icons/copy.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.toolButton_copy_url.setIcon(icon2)
 
         self.horizontalLayout_3.addWidget(self.toolButton_copy_url)
@@ -90,32 +103,32 @@ class Ui_Form(object):
 
         self.verticalLayout.addLayout(self.horizontalLayout_3)
 
-        self.verticalSpacer_2 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.verticalSpacer_2 = QSpacerItem(20, 228, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.verticalLayout.addItem(self.verticalSpacer_2)
 
         self.horizontalLayout = QHBoxLayout()
         self.horizontalLayout.setObjectName(u"horizontalLayout")
-        self.pushButton_create_new_spine_db = QPushButton(Form)
+        self.pushButton_create_new_spine_db = QPushButton(self.scrollAreaWidgetContents)
         self.pushButton_create_new_spine_db.setObjectName(u"pushButton_create_new_spine_db")
-        sizePolicy1 = QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
+        sizePolicy1 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Fixed)
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
         sizePolicy1.setHeightForWidth(self.pushButton_create_new_spine_db.sizePolicy().hasHeightForWidth())
         self.pushButton_create_new_spine_db.setSizePolicy(sizePolicy1)
         icon3 = QIcon()
-        icon3.addFile(u":/icons/Spine_symbol.png", QSize(), QIcon.Normal, QIcon.Off)
+        icon3.addFile(u":/icons/Spine_symbol.png", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.pushButton_create_new_spine_db.setIcon(icon3)
 
         self.horizontalLayout.addWidget(self.pushButton_create_new_spine_db)
 
-        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.horizontalLayout.addItem(self.horizontalSpacer)
 
-        self.pushButton_ds_open_editor = QPushButton(Form)
+        self.pushButton_ds_open_editor = QPushButton(self.scrollAreaWidgetContents)
         self.pushButton_ds_open_editor.setObjectName(u"pushButton_ds_open_editor")
-        sizePolicy2 = QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Preferred)
+        sizePolicy2 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Preferred)
         sizePolicy2.setHorizontalStretch(0)
         sizePolicy2.setVerticalStretch(0)
         sizePolicy2.setHeightForWidth(self.pushButton_ds_open_editor.sizePolicy().hasHeightForWidth())
@@ -125,6 +138,10 @@ class Ui_Form(object):
 
 
         self.verticalLayout.addLayout(self.horizontalLayout)
+
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.verticalLayout_3.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.purge_button, self.toolButton_vacuum)
         QWidget.setTabOrder(self.toolButton_vacuum, self.toolButton_copy_url)

--- a/spine_items/data_store/ui/data_store_properties.ui
+++ b/spine_items/data_store/ui/data_store_properties.ui
@@ -2,6 +2,7 @@
 <!--
 ######################################################################################################################
 # Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Items contributors
 # This file is part of Spine Items.
 # Spine Items is free software: you can redistribute it and\/or modify it under the terms of the GNU Lesser General
 # Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
@@ -25,161 +26,210 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>URL</string>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <property name="leftMargin">
-       <number>3</number>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>367</width>
+        <height>335</height>
+       </rect>
       </property>
-      <property name="topMargin">
-       <number>3</number>
-      </property>
-      <property name="rightMargin">
-       <number>3</number>
-      </property>
-      <property name="bottomMargin">
-       <number>3</number>
-      </property>
-      <item>
-       <widget class="UrlSelectorWidget" name="url_selector_widget" native="true"/>
-      </item>
-     </layout>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>URL</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="leftMargin">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>3</number>
+          </property>
+          <property name="rightMargin">
+           <number>3</number>
+          </property>
+          <property name="bottomMargin">
+           <number>3</number>
+          </property>
+          <item>
+           <widget class="UrlSelectorWidget" name="url_selector_widget" native="true"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QPushButton" name="purge_button">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Mass remove database items.</string>
+           </property>
+           <property name="text">
+            <string>Purge...</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../ui/resources/resources_icons.qrc">
+             <normaloff>:/icons/bolt-lightning.svg</normaloff>:/icons/bolt-lightning.svg</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="toolButton_vacuum">
+           <property name="toolTip">
+            <string>Remove outdated data from the database potentially freeing disk space.</string>
+           </property>
+           <property name="text">
+            <string>Vacuum</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../ui/resources/resources_icons.qrc">
+             <normaloff>:/icons/broom.svg</normaloff>:/icons/broom.svg</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="toolButton_copy_url">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy current database url to clipboard.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Copy URL</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../ui/resources/resources_icons.qrc">
+             <normaloff>:/icons/copy.svg</normaloff>:/icons/copy.svg</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>228</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QPushButton" name="pushButton_create_new_spine_db">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create new Spine database at the selected URL, or at a default one if the selected is not valid.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>New Spine db</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../ui/resources/resources_icons.qrc">
+             <normaloff>:/icons/Spine_symbol.png</normaloff>:/icons/Spine_symbol.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_ds_open_editor">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open URL in Spine database editor&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Open editor...</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QPushButton" name="purge_button">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>Mass remove database items.</string>
-       </property>
-       <property name="text">
-        <string>Purge...</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../ui/resources/resources_icons.qrc">
-         <normaloff>:/icons/bolt-lightning.svg</normaloff>:/icons/bolt-lightning.svg</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="toolButton_vacuum">
-       <property name="toolTip">
-        <string>Remove outdated data from the database potentially freeing disk space.</string>
-       </property>
-       <property name="text">
-        <string>Vacuum</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../ui/resources/resources_icons.qrc">
-         <normaloff>:/icons/broom.svg</normaloff>:/icons/broom.svg</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="toolButton_copy_url">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy current database url to clipboard.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Copy URL</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../ui/resources/resources_icons.qrc">
-         <normaloff>:/icons/copy.svg</normaloff>:/icons/copy.svg</iconset>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="pushButton_create_new_spine_db">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create new Spine database at the selected URL, or at a default one if the selected is not valid.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>New Spine db</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../ui/resources/resources_icons.qrc">
-         <normaloff>:/icons/Spine_symbol.png</normaloff>:/icons/Spine_symbol.png</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButton_ds_open_editor">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open URL in Spine database editor&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Open editor...</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/spine_items/data_transformer/ui/data_transformer_properties.py
+++ b/spine_items/data_transformer/ui/data_transformer_properties.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'data_transformer_properties.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.6.3
+## Created by: Qt User Interface Compiler version 6.7.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -27,8 +27,8 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QApplication, QComboBox, QHBoxLayout, QLabel,
-    QSizePolicy, QSpacerItem, QToolButton, QVBoxLayout,
-    QWidget)
+    QScrollArea, QSizePolicy, QSpacerItem, QToolButton,
+    QVBoxLayout, QWidget)
 from spine_items import resources_icons_rc
 
 class Ui_Form(object):
@@ -37,11 +37,23 @@ class Ui_Form(object):
             Form.setObjectName(u"Form")
         Form.resize(212, 91)
         self.verticalLayout = QVBoxLayout(Form)
+        self.verticalLayout.setSpacing(0)
         self.verticalLayout.setObjectName(u"verticalLayout")
+        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
+        self.scrollArea = QScrollArea(Form)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 210, 89))
+        self.verticalLayout_2 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_2.setSpacing(0)
+        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.verticalLayout_2.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_9 = QHBoxLayout()
         self.horizontalLayout_9.setSpacing(4)
         self.horizontalLayout_9.setObjectName(u"horizontalLayout_9")
-        self.specification_label = QLabel(Form)
+        self.specification_label = QLabel(self.scrollAreaWidgetContents)
         self.specification_label.setObjectName(u"specification_label")
         sizePolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
@@ -52,7 +64,7 @@ class Ui_Form(object):
 
         self.horizontalLayout_9.addWidget(self.specification_label)
 
-        self.specification_combo_box = QComboBox(Form)
+        self.specification_combo_box = QComboBox(self.scrollAreaWidgetContents)
         self.specification_combo_box.setObjectName(u"specification_combo_box")
         sizePolicy1 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         sizePolicy1.setHorizontalStretch(0)
@@ -62,21 +74,25 @@ class Ui_Form(object):
 
         self.horizontalLayout_9.addWidget(self.specification_combo_box)
 
-        self.specification_button = QToolButton(Form)
+        self.specification_button = QToolButton(self.scrollAreaWidgetContents)
         self.specification_button.setObjectName(u"specification_button")
         icon = QIcon()
-        icon.addFile(u":/icons/wrench.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon.addFile(u":/icons/wrench.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.specification_button.setIcon(icon)
-        self.specification_button.setPopupMode(QToolButton.InstantPopup)
+        self.specification_button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
 
         self.horizontalLayout_9.addWidget(self.specification_button)
 
 
-        self.verticalLayout.addLayout(self.horizontalLayout_9)
+        self.verticalLayout_2.addLayout(self.horizontalLayout_9)
 
         self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
-        self.verticalLayout.addItem(self.verticalSpacer)
+        self.verticalLayout_2.addItem(self.verticalSpacer)
+
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.verticalLayout.addWidget(self.scrollArea)
 
 
         self.retranslateUi(Form)

--- a/spine_items/data_transformer/ui/data_transformer_properties.ui
+++ b/spine_items/data_transformer/ui/data_transformer_properties.ui
@@ -27,71 +27,120 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_9">
-     <property name="spacing">
-      <number>4</number>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
      </property>
-     <item>
-      <widget class="QLabel" name="specification_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>210</width>
+        <height>89</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="spacing">
+        <number>0</number>
        </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string>Specification:</string>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="specification_combo_box">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tool specification for this Tool&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="specification_button">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit specification.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../ui/resources/resources_icons.qrc">
-         <normaloff>:/icons/wrench.svg</normaloff>:/icons/wrench.svg</iconset>
-       </property>
-       <property name="popupMode">
-        <enum>QToolButton::InstantPopup</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_9">
+         <property name="spacing">
+          <number>4</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="specification_label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Specification:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="specification_combo_box">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tool specification for this Tool&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="specification_button">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit specification.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../ui/resources/resources_icons.qrc">
+             <normaloff>:/icons/wrench.svg</normaloff>:/icons/wrench.svg</iconset>
+           </property>
+           <property name="popupMode">
+            <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/spine_items/exporter/ui/exporter_properties.py
+++ b/spine_items/exporter/ui/exporter_properties.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'exporter_properties.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.5.2
+## Created by: Qt User Interface Compiler version 6.7.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -27,8 +27,8 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QFrame,
-    QHBoxLayout, QLabel, QSizePolicy, QSpacerItem,
-    QToolButton, QVBoxLayout, QWidget)
+    QHBoxLayout, QLabel, QScrollArea, QSizePolicy,
+    QSpacerItem, QToolButton, QVBoxLayout, QWidget)
 from spine_items import resources_icons_rc
 
 class Ui_Form(object):
@@ -36,14 +36,26 @@ class Ui_Form(object):
         if not Form.objectName():
             Form.setObjectName(u"Form")
         Form.resize(272, 202)
-        self.verticalLayout = QVBoxLayout(Form)
+        self.verticalLayout_3 = QVBoxLayout(Form)
+        self.verticalLayout_3.setSpacing(0)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
+        self.verticalLayout_3.setContentsMargins(0, 0, 0, 0)
+        self.scrollArea = QScrollArea(Form)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 270, 200))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout.setSpacing(0)
         self.verticalLayout.setObjectName(u"verticalLayout")
+        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_9 = QHBoxLayout()
         self.horizontalLayout_9.setSpacing(4)
         self.horizontalLayout_9.setObjectName(u"horizontalLayout_9")
-        self.specification_label = QLabel(Form)
+        self.specification_label = QLabel(self.scrollAreaWidgetContents)
         self.specification_label.setObjectName(u"specification_label")
-        sizePolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.specification_label.sizePolicy().hasHeightForWidth())
@@ -52,9 +64,9 @@ class Ui_Form(object):
 
         self.horizontalLayout_9.addWidget(self.specification_label)
 
-        self.specification_combo_box = QComboBox(Form)
+        self.specification_combo_box = QComboBox(self.scrollAreaWidgetContents)
         self.specification_combo_box.setObjectName(u"specification_combo_box")
-        sizePolicy1 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        sizePolicy1 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
         sizePolicy1.setHeightForWidth(self.specification_combo_box.sizePolicy().hasHeightForWidth())
@@ -62,19 +74,19 @@ class Ui_Form(object):
 
         self.horizontalLayout_9.addWidget(self.specification_combo_box)
 
-        self.specification_button = QToolButton(Form)
+        self.specification_button = QToolButton(self.scrollAreaWidgetContents)
         self.specification_button.setObjectName(u"specification_button")
         icon = QIcon()
-        icon.addFile(u":/icons/wrench.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon.addFile(u":/icons/wrench.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.specification_button.setIcon(icon)
-        self.specification_button.setPopupMode(QToolButton.InstantPopup)
+        self.specification_button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
 
         self.horizontalLayout_9.addWidget(self.specification_button)
 
 
         self.verticalLayout.addLayout(self.horizontalLayout_9)
 
-        self.message_label = QLabel(Form)
+        self.message_label = QLabel(self.scrollAreaWidgetContents)
         self.message_label.setObjectName(u"message_label")
         self.message_label.setWordWrap(True)
 
@@ -86,14 +98,14 @@ class Ui_Form(object):
 
         self.verticalLayout.addLayout(self.outputs_list_layout)
 
-        self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.verticalSpacer = QSpacerItem(20, 71, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.verticalLayout.addItem(self.verticalSpacer)
 
-        self.frame = QFrame(Form)
+        self.frame = QFrame(self.scrollAreaWidgetContents)
         self.frame.setObjectName(u"frame")
-        self.frame.setFrameShape(QFrame.StyledPanel)
-        self.frame.setFrameShadow(QFrame.Raised)
+        self.frame.setFrameShape(QFrame.Shape.StyledPanel)
+        self.frame.setFrameShadow(QFrame.Shadow.Raised)
         self.verticalLayout_2 = QVBoxLayout(self.frame)
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
         self.output_time_stamps_check_box = QCheckBox(self.frame)
@@ -109,6 +121,10 @@ class Ui_Form(object):
 
 
         self.verticalLayout.addWidget(self.frame)
+
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.verticalLayout_3.addWidget(self.scrollArea)
 
 
         self.retranslateUi(Form)

--- a/spine_items/exporter/ui/exporter_properties.ui
+++ b/spine_items/exporter/ui/exporter_properties.ui
@@ -2,6 +2,7 @@
 <!--
 ######################################################################################################################
 # Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Items contributors
 # This file is part of Spine Items.
 # Spine Items is free software: you can redistribute it and\/or modify it under the terms of the GNU Lesser General
 # Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
@@ -25,120 +26,169 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_9">
-     <property name="spacing">
-      <number>4</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="specification_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Specification:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="specification_combo_box">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tool specification for this Tool&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="specification_button">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit specification.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../ui/resources/resources_icons.qrc">
-         <normaloff>:/icons/wrench.svg</normaloff>:/icons/wrench.svg</iconset>
-       </property>
-       <property name="popupMode">
-        <enum>QToolButton::InstantPopup</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QLabel" name="message_label">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="wordWrap">
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
       <bool>true</bool>
      </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QVBoxLayout" name="outputs_list_layout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-    </layout>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="QCheckBox" name="output_time_stamps_check_box">
-        <property name="toolTip">
-         <string>Checking this will add time stamps to output directory names.</string>
-        </property>
-        <property name="text">
-         <string>Time stamp output directories</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="cancel_on_error_check_box">
-        <property name="text">
-         <string>Cancel export on error</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>270</width>
+        <height>200</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_9">
+         <property name="spacing">
+          <number>4</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="specification_label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Specification:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="specification_combo_box">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tool specification for this Tool&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="specification_button">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit specification.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../ui/resources/resources_icons.qrc">
+             <normaloff>:/icons/wrench.svg</normaloff>:/icons/wrench.svg</iconset>
+           </property>
+           <property name="popupMode">
+            <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="message_label">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="outputs_list_layout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>71</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QFrame" name="frame">
+         <property name="frameShape">
+          <enum>QFrame::Shape::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Shadow::Raised</enum>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="output_time_stamps_check_box">
+            <property name="toolTip">
+             <string>Checking this will add time stamps to output directory names.</string>
+            </property>
+            <property name="text">
+             <string>Time stamp output directories</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cancel_on_error_check_box">
+            <property name="text">
+             <string>Cancel export on error</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/spine_items/exporter/ui/value_type_filter_editor.py
+++ b/spine_items/exporter/ui/value_type_filter_editor.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'value_type_filter_editor.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.6.3
+## Created by: Qt User Interface Compiler version 6.7.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/spine_items/importer/ui/import_editor_window.py
+++ b/spine_items/importer/ui/import_editor_window.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'import_editor_window.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.7.3
+## Created by: Qt User Interface Compiler version 6.7.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/spine_items/importer/ui/importer_properties.py
+++ b/spine_items/importer/ui/importer_properties.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'importer_properties.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.5.2
+## Created by: Qt User Interface Compiler version 6.7.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -28,23 +28,35 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QFrame,
     QHBoxLayout, QHeaderView, QLabel, QRadioButton,
-    QSizePolicy, QToolButton, QTreeView, QVBoxLayout,
-    QWidget)
+    QScrollArea, QSizePolicy, QToolButton, QTreeView,
+    QVBoxLayout, QWidget)
 from spine_items import resources_icons_rc
 
 class Ui_Form(object):
     def setupUi(self, Form):
         if not Form.objectName():
             Form.setObjectName(u"Form")
-        Form.resize(375, 368)
+        Form.resize(329, 338)
         self.verticalLayout = QVBoxLayout(Form)
+        self.verticalLayout.setSpacing(0)
         self.verticalLayout.setObjectName(u"verticalLayout")
+        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
+        self.scrollArea = QScrollArea(Form)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 327, 336))
+        self.verticalLayout_3 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_3.setSpacing(0)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
+        self.verticalLayout_3.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_9 = QHBoxLayout()
         self.horizontalLayout_9.setSpacing(4)
         self.horizontalLayout_9.setObjectName(u"horizontalLayout_9")
-        self.label_specification = QLabel(Form)
+        self.label_specification = QLabel(self.scrollAreaWidgetContents)
         self.label_specification.setObjectName(u"label_specification")
-        sizePolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.label_specification.sizePolicy().hasHeightForWidth())
@@ -53,9 +65,9 @@ class Ui_Form(object):
 
         self.horizontalLayout_9.addWidget(self.label_specification)
 
-        self.comboBox_specification = QComboBox(Form)
+        self.comboBox_specification = QComboBox(self.scrollAreaWidgetContents)
         self.comboBox_specification.setObjectName(u"comboBox_specification")
-        sizePolicy1 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        sizePolicy1 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
         sizePolicy1.setHeightForWidth(self.comboBox_specification.sizePolicy().hasHeightForWidth())
@@ -63,30 +75,30 @@ class Ui_Form(object):
 
         self.horizontalLayout_9.addWidget(self.comboBox_specification)
 
-        self.toolButton_edit_specification = QToolButton(Form)
+        self.toolButton_edit_specification = QToolButton(self.scrollAreaWidgetContents)
         self.toolButton_edit_specification.setObjectName(u"toolButton_edit_specification")
         icon = QIcon()
-        icon.addFile(u":/icons/wrench.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon.addFile(u":/icons/wrench.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.toolButton_edit_specification.setIcon(icon)
-        self.toolButton_edit_specification.setPopupMode(QToolButton.InstantPopup)
+        self.toolButton_edit_specification.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
 
         self.horizontalLayout_9.addWidget(self.toolButton_edit_specification)
 
 
-        self.verticalLayout.addLayout(self.horizontalLayout_9)
+        self.verticalLayout_3.addLayout(self.horizontalLayout_9)
 
-        self.treeView_files = QTreeView(Form)
+        self.treeView_files = QTreeView(self.scrollAreaWidgetContents)
         self.treeView_files.setObjectName(u"treeView_files")
-        self.treeView_files.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.treeView_files.setTextElideMode(Qt.ElideLeft)
+        self.treeView_files.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.treeView_files.setTextElideMode(Qt.TextElideMode.ElideLeft)
         self.treeView_files.setUniformRowHeights(True)
 
-        self.verticalLayout.addWidget(self.treeView_files)
+        self.verticalLayout_3.addWidget(self.treeView_files)
 
-        self.frame = QFrame(Form)
+        self.frame = QFrame(self.scrollAreaWidgetContents)
         self.frame.setObjectName(u"frame")
-        self.frame.setFrameShape(QFrame.StyledPanel)
-        self.frame.setFrameShadow(QFrame.Raised)
+        self.frame.setFrameShape(QFrame.Shape.StyledPanel)
+        self.frame.setFrameShadow(QFrame.Shadow.Raised)
         self.verticalLayout_2 = QVBoxLayout(self.frame)
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
         self.verticalLayout_2.setContentsMargins(-1, 0, -1, -1)
@@ -122,7 +134,11 @@ class Ui_Form(object):
         self.verticalLayout_2.addLayout(self.horizontalLayout)
 
 
-        self.verticalLayout.addWidget(self.frame)
+        self.verticalLayout_3.addWidget(self.frame)
+
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.verticalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.comboBox_specification, self.toolButton_edit_specification)
         QWidget.setTabOrder(self.toolButton_edit_specification, self.treeView_files)

--- a/spine_items/importer/ui/importer_properties.ui
+++ b/spine_items/importer/ui/importer_properties.ui
@@ -19,138 +19,187 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>375</width>
-    <height>368</height>
+    <width>329</width>
+    <height>338</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_9">
-     <property name="spacing">
-      <number>4</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="label_specification">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Specification:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboBox_specification">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specification for this Importer&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="toolButton_edit_specification">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit specification.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../ui/resources/resources_icons.qrc">
-         <normaloff>:/icons/wrench.svg</normaloff>:/icons/wrench.svg</iconset>
-       </property>
-       <property name="popupMode">
-        <enum>QToolButton::InstantPopup</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QTreeView" name="treeView_files">
-     <property name="contextMenuPolicy">
-      <enum>Qt::CustomContextMenu</enum>
-     </property>
-     <property name="textElideMode">
-      <enum>Qt::ElideLeft</enum>
-     </property>
-     <property name="uniformRowHeights">
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
       <bool>true</bool>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <property name="topMargin">
-       <number>0</number>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>327</width>
+        <height>336</height>
+       </rect>
       </property>
-      <item>
-       <widget class="QCheckBox" name="cancel_on_error_checkBox">
-        <property name="toolTip">
-         <string>If there are any errors when trying to import data cancel the whole import.</string>
-        </property>
-        <property name="text">
-         <string>Cancel import on error</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>If values already exist</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QRadioButton" name="radioButton_on_conflict_keep">
-          <property name="text">
-           <string>Keep existing</string>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_9">
+         <property name="spacing">
+          <number>4</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_specification">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Specification:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="comboBox_specification">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specification for this Importer&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="toolButton_edit_specification">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit specification.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../ui/resources/resources_icons.qrc">
+             <normaloff>:/icons/wrench.svg</normaloff>:/icons/wrench.svg</iconset>
+           </property>
+           <property name="popupMode">
+            <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QTreeView" name="treeView_files">
+         <property name="contextMenuPolicy">
+          <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
+         </property>
+         <property name="textElideMode">
+          <enum>Qt::TextElideMode::ElideLeft</enum>
+         </property>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QFrame" name="frame">
+         <property name="frameShape">
+          <enum>QFrame::Shape::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Shadow::Raised</enum>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="topMargin">
+           <number>0</number>
           </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="radioButton_on_conflict_replace">
-          <property name="text">
-           <string>Replace</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="radioButton_on_conflict_merge">
-          <property name="text">
-           <string>Merge indexes</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
+          <item>
+           <widget class="QCheckBox" name="cancel_on_error_checkBox">
+            <property name="toolTip">
+             <string>If there are any errors when trying to import data cancel the whole import.</string>
+            </property>
+            <property name="text">
+             <string>Cancel import on error</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>If values already exist</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QRadioButton" name="radioButton_on_conflict_keep">
+              <property name="text">
+               <string>Keep existing</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="radioButton_on_conflict_replace">
+              <property name="text">
+               <string>Replace</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="radioButton_on_conflict_merge">
+              <property name="text">
+               <string>Merge indexes</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/spine_items/merger/ui/merger_properties.py
+++ b/spine_items/merger/ui/merger_properties.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'merger_properties.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.5.2
+## Created by: Qt User Interface Compiler version 6.7.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -26,8 +26,8 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
-from PySide6.QtWidgets import (QApplication, QCheckBox, QFrame, QSizePolicy,
-    QSpacerItem, QVBoxLayout, QWidget)
+from PySide6.QtWidgets import (QApplication, QCheckBox, QFrame, QScrollArea,
+    QSizePolicy, QSpacerItem, QVBoxLayout, QWidget)
 from spine_items import resources_icons_rc
 
 class Ui_Form(object):
@@ -35,16 +35,28 @@ class Ui_Form(object):
         if not Form.objectName():
             Form.setObjectName(u"Form")
         Form.resize(323, 228)
-        self.verticalLayout = QVBoxLayout(Form)
+        self.verticalLayout_3 = QVBoxLayout(Form)
+        self.verticalLayout_3.setSpacing(0)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
+        self.verticalLayout_3.setContentsMargins(0, 0, 0, 0)
+        self.scrollArea = QScrollArea(Form)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 321, 226))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout.setSpacing(0)
         self.verticalLayout.setObjectName(u"verticalLayout")
-        self.verticalSpacer_2 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
+        self.verticalSpacer_2 = QSpacerItem(20, 165, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.verticalLayout.addItem(self.verticalSpacer_2)
 
-        self.frame = QFrame(Form)
+        self.frame = QFrame(self.scrollAreaWidgetContents)
         self.frame.setObjectName(u"frame")
-        self.frame.setFrameShape(QFrame.StyledPanel)
-        self.frame.setFrameShadow(QFrame.Raised)
+        self.frame.setFrameShape(QFrame.Shape.StyledPanel)
+        self.frame.setFrameShadow(QFrame.Shadow.Raised)
         self.verticalLayout_2 = QVBoxLayout(self.frame)
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
         self.cancel_on_error_checkBox = QCheckBox(self.frame)
@@ -55,6 +67,10 @@ class Ui_Form(object):
 
 
         self.verticalLayout.addWidget(self.frame)
+
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.verticalLayout_3.addWidget(self.scrollArea)
 
 
         self.retranslateUi(Form)

--- a/spine_items/merger/ui/merger_properties.ui
+++ b/spine_items/merger/ui/merger_properties.ui
@@ -2,6 +2,7 @@
 <!--
 ######################################################################################################################
 # Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Items contributors
 # This file is part of Spine Items.
 # Spine Items is free software: you can redistribute it and\/or modify it under the terms of the GNU Lesser General
 # Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
@@ -25,43 +26,92 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="QCheckBox" name="cancel_on_error_checkBox">
-        <property name="toolTip">
-         <string>If there are any errors when trying to import data cancel the whole import.</string>
-        </property>
-        <property name="text">
-         <string>Cancel on error</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>321</width>
+        <height>226</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>165</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QFrame" name="frame">
+         <property name="frameShape">
+          <enum>QFrame::Shape::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Shadow::Raised</enum>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="cancel_on_error_checkBox">
+            <property name="toolTip">
+             <string>If there are any errors when trying to import data cancel the whole import.</string>
+            </property>
+            <property name="text">
+             <string>Cancel on error</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/spine_items/tool/ui/tool_properties.py
+++ b/spine_items/tool/ui/tool_properties.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'tool_properties.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.6.3
+## Created by: Qt User Interface Compiler version 6.7.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -29,8 +29,8 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
 from PySide6.QtWidgets import (QAbstractItemView, QApplication, QCheckBox, QComboBox,
     QFrame, QGridLayout, QHBoxLayout, QHeaderView,
     QLabel, QLineEdit, QPushButton, QRadioButton,
-    QSizePolicy, QSpacerItem, QSplitter, QToolButton,
-    QTreeView, QVBoxLayout, QWidget)
+    QScrollArea, QSizePolicy, QSpacerItem, QSplitter,
+    QToolButton, QTreeView, QVBoxLayout, QWidget)
 
 from ...widgets import ArgsTreeView
 from spinetoolbox.widgets.custom_qwidgets import ElidedLabel
@@ -42,11 +42,23 @@ class Ui_Form(object):
             Form.setObjectName(u"Form")
         Form.resize(312, 603)
         self.verticalLayout = QVBoxLayout(Form)
+        self.verticalLayout.setSpacing(0)
         self.verticalLayout.setObjectName(u"verticalLayout")
+        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
+        self.scrollArea = QScrollArea(Form)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 310, 601))
+        self.verticalLayout_3 = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout_3.setSpacing(0)
+        self.verticalLayout_3.setObjectName(u"verticalLayout_3")
+        self.verticalLayout_3.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_9 = QHBoxLayout()
         self.horizontalLayout_9.setSpacing(4)
         self.horizontalLayout_9.setObjectName(u"horizontalLayout_9")
-        self.label_tool_specification = QLabel(Form)
+        self.label_tool_specification = QLabel(self.scrollAreaWidgetContents)
         self.label_tool_specification.setObjectName(u"label_tool_specification")
         sizePolicy = QSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
@@ -57,7 +69,7 @@ class Ui_Form(object):
 
         self.horizontalLayout_9.addWidget(self.label_tool_specification)
 
-        self.comboBox_tool = QComboBox(Form)
+        self.comboBox_tool = QComboBox(self.scrollAreaWidgetContents)
         self.comboBox_tool.setObjectName(u"comboBox_tool")
         sizePolicy1 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         sizePolicy1.setHorizontalStretch(0)
@@ -67,26 +79,26 @@ class Ui_Form(object):
 
         self.horizontalLayout_9.addWidget(self.comboBox_tool)
 
-        self.toolButton_tool_specification = QToolButton(Form)
+        self.toolButton_tool_specification = QToolButton(self.scrollAreaWidgetContents)
         self.toolButton_tool_specification.setObjectName(u"toolButton_tool_specification")
         icon = QIcon()
-        icon.addFile(u":/icons/wrench.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon.addFile(u":/icons/wrench.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.toolButton_tool_specification.setIcon(icon)
-        self.toolButton_tool_specification.setPopupMode(QToolButton.InstantPopup)
+        self.toolButton_tool_specification.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
 
         self.horizontalLayout_9.addWidget(self.toolButton_tool_specification)
 
 
-        self.verticalLayout.addLayout(self.horizontalLayout_9)
+        self.verticalLayout_3.addLayout(self.horizontalLayout_9)
 
         self.horizontalLayout_options = QHBoxLayout()
         self.horizontalLayout_options.setObjectName(u"horizontalLayout_options")
 
-        self.verticalLayout.addLayout(self.horizontalLayout_options)
+        self.verticalLayout_3.addLayout(self.horizontalLayout_options)
 
-        self.splitter = QSplitter(Form)
+        self.splitter = QSplitter(self.scrollAreaWidgetContents)
         self.splitter.setObjectName(u"splitter")
-        self.splitter.setOrientation(Qt.Vertical)
+        self.splitter.setOrientation(Qt.Orientation.Vertical)
         self.splitter.setChildrenCollapsible(False)
         self.treeView_cmdline_args = ArgsTreeView(self.splitter)
         self.treeView_cmdline_args.setObjectName(u"treeView_cmdline_args")
@@ -96,10 +108,10 @@ class Ui_Form(object):
         sizePolicy2.setHeightForWidth(self.treeView_cmdline_args.sizePolicy().hasHeightForWidth())
         self.treeView_cmdline_args.setSizePolicy(sizePolicy2)
         self.treeView_cmdline_args.setAcceptDrops(True)
-        self.treeView_cmdline_args.setEditTriggers(QAbstractItemView.AnyKeyPressed|QAbstractItemView.DoubleClicked|QAbstractItemView.EditKeyPressed)
-        self.treeView_cmdline_args.setDragDropMode(QAbstractItemView.DragDrop)
-        self.treeView_cmdline_args.setSelectionMode(QAbstractItemView.ExtendedSelection)
-        self.treeView_cmdline_args.setTextElideMode(Qt.ElideLeft)
+        self.treeView_cmdline_args.setEditTriggers(QAbstractItemView.EditTrigger.AnyKeyPressed|QAbstractItemView.EditTrigger.DoubleClicked|QAbstractItemView.EditTrigger.EditKeyPressed)
+        self.treeView_cmdline_args.setDragDropMode(QAbstractItemView.DragDropMode.DragDrop)
+        self.treeView_cmdline_args.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.treeView_cmdline_args.setTextElideMode(Qt.TextElideMode.ElideLeft)
         self.splitter.addWidget(self.treeView_cmdline_args)
         self.treeView_cmdline_args.header().setMinimumSectionSize(26)
         self.gridLayoutWidget = QWidget(self.splitter)
@@ -114,7 +126,7 @@ class Ui_Form(object):
         self.toolButton_remove_arg = QToolButton(self.gridLayoutWidget)
         self.toolButton_remove_arg.setObjectName(u"toolButton_remove_arg")
         icon1 = QIcon()
-        icon1.addFile(u":/icons/minus.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon1.addFile(u":/icons/minus.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.toolButton_remove_arg.setIcon(icon1)
 
         self.gridLayout.addWidget(self.toolButton_remove_arg, 0, 2, 1, 1)
@@ -122,9 +134,9 @@ class Ui_Form(object):
         self.toolButton_add_file_path_arg = QToolButton(self.gridLayoutWidget)
         self.toolButton_add_file_path_arg.setObjectName(u"toolButton_add_file_path_arg")
         icon2 = QIcon()
-        icon2.addFile(u":/icons/file-upload.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon2.addFile(u":/icons/file-upload.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.toolButton_add_file_path_arg.setIcon(icon2)
-        self.toolButton_add_file_path_arg.setPopupMode(QToolButton.InstantPopup)
+        self.toolButton_add_file_path_arg.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
 
         self.gridLayout.addWidget(self.toolButton_add_file_path_arg, 0, 0, 1, 1)
 
@@ -133,9 +145,9 @@ class Ui_Form(object):
         sizePolicy2.setHeightForWidth(self.treeView_input_files.sizePolicy().hasHeightForWidth())
         self.treeView_input_files.setSizePolicy(sizePolicy2)
         self.treeView_input_files.setDragEnabled(False)
-        self.treeView_input_files.setDragDropMode(QAbstractItemView.DragOnly)
-        self.treeView_input_files.setSelectionMode(QAbstractItemView.ExtendedSelection)
-        self.treeView_input_files.setTextElideMode(Qt.ElideLeft)
+        self.treeView_input_files.setDragDropMode(QAbstractItemView.DragDropMode.DragOnly)
+        self.treeView_input_files.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.treeView_input_files.setTextElideMode(Qt.TextElideMode.ElideLeft)
         self.treeView_input_files.setUniformRowHeights(True)
         self.treeView_input_files.setAnimated(False)
         self.treeView_input_files.header().setMinimumSectionSize(26)
@@ -144,12 +156,12 @@ class Ui_Form(object):
 
         self.splitter.addWidget(self.gridLayoutWidget)
 
-        self.verticalLayout.addWidget(self.splitter)
+        self.verticalLayout_3.addWidget(self.splitter)
 
-        self.frame = QFrame(Form)
+        self.frame = QFrame(self.scrollAreaWidgetContents)
         self.frame.setObjectName(u"frame")
-        self.frame.setFrameShape(QFrame.StyledPanel)
-        self.frame.setFrameShadow(QFrame.Raised)
+        self.frame.setFrameShape(QFrame.Shape.StyledPanel)
+        self.frame.setFrameShadow(QFrame.Shadow.Raised)
         self.verticalLayout_2 = QVBoxLayout(self.frame)
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
         self.label_2 = QLabel(self.frame)
@@ -198,14 +210,6 @@ class Ui_Form(object):
 
         self.verticalLayout_2.addWidget(self.kill_consoles_check_box)
 
-        self.log_process_output_check_box = QCheckBox(self.frame)
-        self.log_process_output_check_box.setObjectName(u"log_process_output_check_box")
-
-        self.verticalLayout_2.addWidget(self.log_process_output_check_box)
-
-
-        self.verticalLayout.addWidget(self.frame)
-
         self.horizontalLayout_11 = QHBoxLayout()
         self.horizontalLayout_11.setSpacing(6)
         self.horizontalLayout_11.setObjectName(u"horizontalLayout_11")
@@ -213,7 +217,7 @@ class Ui_Form(object):
 
         self.horizontalLayout_11.addItem(self.horizontalSpacer_6)
 
-        self.pushButton_tool_results = QPushButton(Form)
+        self.pushButton_tool_results = QPushButton(self.frame)
         self.pushButton_tool_results.setObjectName(u"pushButton_tool_results")
         sizePolicy3 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Fixed)
         sizePolicy3.setHorizontalStretch(0)
@@ -224,7 +228,19 @@ class Ui_Form(object):
         self.horizontalLayout_11.addWidget(self.pushButton_tool_results)
 
 
-        self.verticalLayout.addLayout(self.horizontalLayout_11)
+        self.verticalLayout_2.addLayout(self.horizontalLayout_11)
+
+        self.log_process_output_check_box = QCheckBox(self.frame)
+        self.log_process_output_check_box.setObjectName(u"log_process_output_check_box")
+
+        self.verticalLayout_2.addWidget(self.log_process_output_check_box)
+
+
+        self.verticalLayout_3.addWidget(self.frame)
+
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.verticalLayout.addWidget(self.scrollArea)
 
         QWidget.setTabOrder(self.comboBox_tool, self.toolButton_tool_specification)
         QWidget.setTabOrder(self.toolButton_tool_specification, self.treeView_cmdline_args)
@@ -272,10 +288,10 @@ class Ui_Form(object):
         self.kill_consoles_check_box.setToolTip(QCoreApplication.translate("Form", u"If checked, console processes will be killed automatically after execution finishes freeing memory and other resources.", None))
 #endif // QT_CONFIG(tooltip)
         self.kill_consoles_check_box.setText(QCoreApplication.translate("Form", u"Kill consoles at the end of execution", None))
-        self.log_process_output_check_box.setText(QCoreApplication.translate("Form", u"Log process output to a file", None))
 #if QT_CONFIG(tooltip)
         self.pushButton_tool_results.setToolTip(QCoreApplication.translate("Form", u"<html><head/><body><p>Open results archive in file browser</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.pushButton_tool_results.setText(QCoreApplication.translate("Form", u"Results...", None))
+        self.log_process_output_check_box.setText(QCoreApplication.translate("Form", u"Log process output to a file", None))
     # retranslateUi
 

--- a/spine_items/tool/ui/tool_properties.ui
+++ b/spine_items/tool/ui/tool_properties.ui
@@ -27,294 +27,343 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_9">
-     <property name="spacing">
-      <number>4</number>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
      </property>
-     <item>
-      <widget class="QLabel" name="label_tool_specification">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Specification:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboBox_tool">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tool specification for this Tool&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="toolButton_tool_specification">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tool specification options.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../ui/resources/resources_icons.qrc">
-         <normaloff>:/icons/wrench.svg</normaloff>:/icons/wrench.svg</iconset>
-       </property>
-       <property name="popupMode">
-        <enum>QToolButton::InstantPopup</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_options"/>
-   </item>
-   <item>
-    <widget class="QSplitter" name="splitter">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="childrenCollapsible">
-      <bool>false</bool>
-     </property>
-     <widget class="ArgsTreeView" name="treeView_cmdline_args">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>310</width>
+        <height>601</height>
+       </rect>
       </property>
-      <property name="acceptDrops">
-       <bool>true</bool>
-      </property>
-      <property name="editTriggers">
-       <set>QAbstractItemView::AnyKeyPressed|QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
-      </property>
-      <property name="dragDropMode">
-       <enum>QAbstractItemView::DragDrop</enum>
-      </property>
-      <property name="selectionMode">
-       <enum>QAbstractItemView::ExtendedSelection</enum>
-      </property>
-      <property name="textElideMode">
-       <enum>Qt::ElideLeft</enum>
-      </property>
-      <attribute name="headerMinimumSectionSize">
-       <number>26</number>
-      </attribute>
-     </widget>
-     <widget class="QWidget" name="gridLayoutWidget">
-      <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="1">
-        <spacer name="horizontalSpacer_2">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_9">
+         <property name="spacing">
+          <number>4</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_tool_specification">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Specification:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="comboBox_tool">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tool specification for this Tool&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="toolButton_tool_specification">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tool specification options.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../ui/resources/resources_icons.qrc">
+             <normaloff>:/icons/wrench.svg</normaloff>:/icons/wrench.svg</iconset>
+           </property>
+           <property name="popupMode">
+            <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_options"/>
+       </item>
+       <item>
+        <widget class="QSplitter" name="splitter">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="0" column="2">
-        <widget class="QToolButton" name="toolButton_remove_arg">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove selected tool command line args&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>...</string>
-         </property>
-         <property name="icon">
-          <iconset resource="../../ui/resources/resources_icons.qrc">
-           <normaloff>:/icons/minus.svg</normaloff>:/icons/minus.svg</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QToolButton" name="toolButton_add_file_path_arg">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Append selected Available resources to Tool arguments&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../ui/resources/resources_icons.qrc">
-           <normaloff>:/icons/file-upload.svg</normaloff>:/icons/file-upload.svg</iconset>
-         </property>
-         <property name="popupMode">
-          <enum>QToolButton::InstantPopup</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0" colspan="3">
-        <widget class="QTreeView" name="treeView_input_files">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="dragEnabled">
+         <property name="childrenCollapsible">
           <bool>false</bool>
          </property>
-         <property name="dragDropMode">
-          <enum>QAbstractItemView::DragOnly</enum>
+         <widget class="ArgsTreeView" name="treeView_cmdline_args">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="acceptDrops">
+           <bool>true</bool>
+          </property>
+          <property name="editTriggers">
+           <set>QAbstractItemView::EditTrigger::AnyKeyPressed|QAbstractItemView::EditTrigger::DoubleClicked|QAbstractItemView::EditTrigger::EditKeyPressed</set>
+          </property>
+          <property name="dragDropMode">
+           <enum>QAbstractItemView::DragDropMode::DragDrop</enum>
+          </property>
+          <property name="selectionMode">
+           <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+          </property>
+          <property name="textElideMode">
+           <enum>Qt::TextElideMode::ElideLeft</enum>
+          </property>
+          <attribute name="headerMinimumSectionSize">
+           <number>26</number>
+          </attribute>
+         </widget>
+         <widget class="QWidget" name="gridLayoutWidget">
+          <layout class="QGridLayout" name="gridLayout">
+           <item row="0" column="1">
+            <spacer name="horizontalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="2">
+            <widget class="QToolButton" name="toolButton_remove_arg">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove selected tool command line args&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../../ui/resources/resources_icons.qrc">
+               <normaloff>:/icons/minus.svg</normaloff>:/icons/minus.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QToolButton" name="toolButton_add_file_path_arg">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Append selected Available resources to Tool arguments&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset resource="../../ui/resources/resources_icons.qrc">
+               <normaloff>:/icons/file-upload.svg</normaloff>:/icons/file-upload.svg</iconset>
+             </property>
+             <property name="popupMode">
+              <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="3">
+            <widget class="QTreeView" name="treeView_input_files">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="dragEnabled">
+              <bool>false</bool>
+             </property>
+             <property name="dragDropMode">
+              <enum>QAbstractItemView::DragDropMode::DragOnly</enum>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+             </property>
+             <property name="textElideMode">
+              <enum>Qt::TextElideMode::ElideLeft</enum>
+             </property>
+             <property name="uniformRowHeights">
+              <bool>true</bool>
+             </property>
+             <property name="animated">
+              <bool>false</bool>
+             </property>
+             <attribute name="headerMinimumSectionSize">
+              <number>26</number>
+             </attribute>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+       <item>
+        <widget class="QFrame" name="frame">
+         <property name="frameShape">
+          <enum>QFrame::Shape::StyledPanel</enum>
          </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::ExtendedSelection</enum>
+         <property name="frameShadow">
+          <enum>QFrame::Shadow::Raised</enum>
          </property>
-         <property name="textElideMode">
-          <enum>Qt::ElideLeft</enum>
-         </property>
-         <property name="uniformRowHeights">
-          <bool>true</bool>
-         </property>
-         <property name="animated">
-          <bool>false</bool>
-         </property>
-         <attribute name="headerMinimumSectionSize">
-          <number>26</number>
-         </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Execute in</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QRadioButton" name="radioButton_execute_in_source">
+              <property name="text">
+               <string>Source directory</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="radioButton_execute_in_work">
+              <property name="text">
+               <string>Work directory</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="label_group_id">
+              <property name="text">
+               <string>Reuse console id:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="lineEdit_group_id">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter an id for sharing a console with other Tools in this project. Leave empty to run this Tool in isolation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="ElidedLabel" name="label_jupyter">
+            <property name="text">
+             <string>Console info</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="kill_consoles_check_box">
+            <property name="toolTip">
+             <string>If checked, console processes will be killed automatically after execution finishes freeing memory and other resources.</string>
+            </property>
+            <property name="text">
+             <string>Kill consoles at the end of execution</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_11">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <spacer name="horizontalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pushButton_tool_results">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open results archive in file browser&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Results...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="log_process_output_check_box">
+            <property name="text">
+             <string>Log process output to a file</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
       </layout>
      </widget>
     </widget>
-   </item>
-   <item>
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Execute in</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QRadioButton" name="radioButton_execute_in_source">
-          <property name="text">
-           <string>Source directory</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="radioButton_execute_in_work">
-          <property name="text">
-           <string>Work directory</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QLabel" name="label_group_id">
-          <property name="text">
-           <string>Reuse console id:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="lineEdit_group_id">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter an id for sharing a console with other Tools in this project. Leave empty to run this Tool in isolation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="ElidedLabel" name="label_jupyter">
-        <property name="text">
-         <string>Console info</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="kill_consoles_check_box">
-        <property name="toolTip">
-         <string>If checked, console processes will be killed automatically after execution finishes freeing memory and other resources.</string>
-        </property>
-        <property name="text">
-         <string>Kill consoles at the end of execution</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="log_process_output_check_box">
-        <property name="text">
-         <string>Log process output to a file</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_11">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <item>
-      <spacer name="horizontalSpacer_6">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButton_tool_results">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open results archive in file browser&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Results...</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/spine_items/tool/ui/tool_specification_form.py
+++ b/spine_items/tool/ui/tool_specification_form.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'tool_specification_form.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.7.3
+## Created by: Qt User Interface Compiler version 6.7.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/spine_items/view/ui/view_properties.py
+++ b/spine_items/view/ui/view_properties.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'view_properties.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.5.2
+## Created by: Qt User Interface Compiler version 6.7.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -27,8 +27,8 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QAbstractItemView, QApplication, QHBoxLayout, QHeaderView,
-    QPushButton, QSizePolicy, QSpacerItem, QTreeView,
-    QVBoxLayout, QWidget)
+    QPushButton, QScrollArea, QSizePolicy, QSpacerItem,
+    QTreeView, QVBoxLayout, QWidget)
 
 from spine_items.widgets import ReferencesTreeView
 from spine_items import resources_icons_rc
@@ -37,15 +37,27 @@ class Ui_Form(object):
     def setupUi(self, Form):
         if not Form.objectName():
             Form.setObjectName(u"Form")
-        Form.resize(274, 241)
-        self.verticalLayout = QVBoxLayout(Form)
+        Form.resize(262, 346)
+        self.verticalLayout_2 = QVBoxLayout(Form)
+        self.verticalLayout_2.setSpacing(0)
+        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.verticalLayout_2.setContentsMargins(0, 0, 0, 0)
+        self.scrollArea = QScrollArea(Form)
+        self.scrollArea.setObjectName(u"scrollArea")
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollAreaWidgetContents = QWidget()
+        self.scrollAreaWidgetContents.setObjectName(u"scrollAreaWidgetContents")
+        self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 260, 344))
+        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
+        self.verticalLayout.setSpacing(0)
         self.verticalLayout.setObjectName(u"verticalLayout")
-        self.treeView_references = ReferencesTreeView(Form)
+        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
+        self.treeView_references = ReferencesTreeView(self.scrollAreaWidgetContents)
         self.treeView_references.setObjectName(u"treeView_references")
-        self.treeView_references.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.treeView_references.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.treeView_references.setAcceptDrops(True)
-        self.treeView_references.setSelectionMode(QAbstractItemView.ExtendedSelection)
-        self.treeView_references.setTextElideMode(Qt.ElideLeft)
+        self.treeView_references.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.treeView_references.setTextElideMode(Qt.TextElideMode.ElideLeft)
         self.treeView_references.setRootIsDecorated(False)
 
         self.verticalLayout.addWidget(self.treeView_references)
@@ -53,16 +65,16 @@ class Ui_Form(object):
         self.horizontalLayout_8 = QHBoxLayout()
         self.horizontalLayout_8.setSpacing(6)
         self.horizontalLayout_8.setObjectName(u"horizontalLayout_8")
-        self.pushButton_pin_values = QPushButton(Form)
+        self.pushButton_pin_values = QPushButton(self.scrollAreaWidgetContents)
         self.pushButton_pin_values.setObjectName(u"pushButton_pin_values")
 
         self.horizontalLayout_8.addWidget(self.pushButton_pin_values)
 
-        self.horizontalSpacer_9 = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.horizontalSpacer_9 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.horizontalLayout_8.addItem(self.horizontalSpacer_9)
 
-        self.pushButton_open_editor = QPushButton(Form)
+        self.pushButton_open_editor = QPushButton(self.scrollAreaWidgetContents)
         self.pushButton_open_editor.setObjectName(u"pushButton_open_editor")
 
         self.horizontalLayout_8.addWidget(self.pushButton_open_editor)
@@ -70,27 +82,31 @@ class Ui_Form(object):
 
         self.verticalLayout.addLayout(self.horizontalLayout_8)
 
-        self.treeView_pinned_values = QTreeView(Form)
+        self.treeView_pinned_values = QTreeView(self.scrollAreaWidgetContents)
         self.treeView_pinned_values.setObjectName(u"treeView_pinned_values")
-        self.treeView_pinned_values.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.treeView_pinned_values.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.treeView_pinned_values.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.treeView_pinned_values.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         self.treeView_pinned_values.setRootIsDecorated(False)
 
         self.verticalLayout.addWidget(self.treeView_pinned_values)
 
         self.horizontalLayout = QHBoxLayout()
         self.horizontalLayout.setObjectName(u"horizontalLayout")
-        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.horizontalLayout.addItem(self.horizontalSpacer)
 
-        self.pushButton_plot_pinned = QPushButton(Form)
+        self.pushButton_plot_pinned = QPushButton(self.scrollAreaWidgetContents)
         self.pushButton_plot_pinned.setObjectName(u"pushButton_plot_pinned")
 
         self.horizontalLayout.addWidget(self.pushButton_plot_pinned)
 
 
         self.verticalLayout.addLayout(self.horizontalLayout)
+
+        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
+
+        self.verticalLayout_2.addWidget(self.scrollArea)
 
 
         self.retranslateUi(Form)

--- a/spine_items/view/ui/view_properties.ui
+++ b/spine_items/view/ui/view_properties.ui
@@ -2,6 +2,7 @@
 <!--
 ######################################################################################################################
 # Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Items contributors
 # This file is part of Spine Items.
 # Spine Items is free software: you can redistribute it and\/or modify it under the terms of the GNU Lesser General
 # Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
@@ -18,106 +19,155 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>274</width>
-    <height>241</height>
+    <width>262</width>
+    <height>346</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <widget class="ReferencesTreeView" name="treeView_references">
-     <property name="contextMenuPolicy">
-      <enum>Qt::CustomContextMenu</enum>
-     </property>
-     <property name="acceptDrops">
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
       <bool>true</bool>
      </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="textElideMode">
-      <enum>Qt::ElideLeft</enum>
-     </property>
-     <property name="rootIsDecorated">
-      <bool>false</bool>
-     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>260</width>
+        <height>344</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="ReferencesTreeView" name="treeView_references">
+         <property name="contextMenuPolicy">
+          <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
+         </property>
+         <property name="acceptDrops">
+          <bool>true</bool>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+         </property>
+         <property name="textElideMode">
+          <enum>Qt::TextElideMode::ElideLeft</enum>
+         </property>
+         <property name="rootIsDecorated">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_8" stretch="0,0,0">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="pushButton_pin_values">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open selected database in Spine database editor&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Pin values...</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_9">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_open_editor">
+           <property name="text">
+            <string>Open editor...</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QTreeView" name="treeView_pinned_values">
+         <property name="contextMenuPolicy">
+          <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+         </property>
+         <property name="rootIsDecorated">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton_plot_pinned">
+           <property name="text">
+            <string>Plot</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_8" stretch="0,0,0">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <item>
-      <widget class="QPushButton" name="pushButton_pin_values">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open selected database in Spine database editor&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Pin values...</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_9">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButton_open_editor">
-       <property name="text">
-        <string>Open editor...</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QTreeView" name="treeView_pinned_values">
-     <property name="contextMenuPolicy">
-      <enum>Qt::CustomContextMenu</enum>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="rootIsDecorated">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButton_plot_pinned">
-       <property name="text">
-        <string>Plot</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/tests/data_connection/test_DataConnection.py
+++ b/tests/data_connection/test_DataConnection.py
@@ -110,11 +110,12 @@ class TestDataConnectionWithProject(unittest.TestCase):
             self.assertEqual(str(a), self._ref_model.index(1, 0, self._ref_model.index(0, 0)).data())
 
     def test_add_db_references(self):
-        with mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.exec"
-        ) as url_selector_exec, mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.url_dict"
-        ) as url_selector_url_dict:
+        with (
+            mock.patch("spine_items.data_connection.data_connection.UrlSelectorDialog.exec") as url_selector_exec,
+            mock.patch(
+                "spine_items.data_connection.data_connection.UrlSelectorDialog.url_dict"
+            ) as url_selector_url_dict,
+        ):
             # Add nothing
             url_selector_exec.return_value = QDialog.DialogCode.Rejected
             self._data_connection.show_add_db_reference_dialog()
@@ -152,15 +153,16 @@ class TestDataConnectionWithProject(unittest.TestCase):
     def test_remove_references(self):
         temp_dir = Path(self._temp_dir.name, "references")
         temp_dir.mkdir()
-        with mock.patch(
-            "spine_items.data_connection.data_connection.QFileDialog.getOpenFileNames"
-        ) as mock_filenames, mock.patch.object(
-            self._data_connection._properties_ui.treeView_dc_references, "selectedIndexes"
-        ) as mock_selected_indexes, mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.exec"
-        ) as url_selector_exec, mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.url_dict"
-        ) as url_selector_url_dict:
+        with (
+            mock.patch("spine_items.data_connection.data_connection.QFileDialog.getOpenFileNames") as mock_filenames,
+            mock.patch.object(
+                self._data_connection._properties_ui.treeView_dc_references, "selectedIndexes"
+            ) as mock_selected_indexes,
+            mock.patch("spine_items.data_connection.data_connection.UrlSelectorDialog.exec") as url_selector_exec,
+            mock.patch(
+                "spine_items.data_connection.data_connection.UrlSelectorDialog.url_dict"
+            ) as url_selector_url_dict,
+        ):
             a = Path(temp_dir, "a.txt")
             a.touch()
             b = Path(temp_dir, "b.txt")
@@ -284,13 +286,13 @@ class TestDataConnectionWithProject(unittest.TestCase):
     def test_remove_references_with_del_key(self):
         temp_dir = Path(self._temp_dir.name, "references")
         temp_dir.mkdir()
-        with mock.patch(
-            "spine_items.data_connection.data_connection.QFileDialog.getOpenFileNames"
-        ) as mock_filenames, mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.exec"
-        ), mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.url", new_callable=mock.PropertyMock
-        ) as url_selector_url:
+        with (
+            mock.patch("spine_items.data_connection.data_connection.QFileDialog.getOpenFileNames") as mock_filenames,
+            mock.patch("spine_items.data_connection.data_connection.UrlSelectorDialog.exec"),
+            mock.patch(
+                "spine_items.data_connection.data_connection.UrlSelectorDialog.url", new_callable=mock.PropertyMock
+            ) as url_selector_url,
+        ):
             a = Path(temp_dir, "a.txt")
             a.touch()
             b = Path(temp_dir, "b.txt")
@@ -447,11 +449,12 @@ class TestDataConnectionWithProject(unittest.TestCase):
             self.assertTrue(k in d, f"Key '{k}' not in dict {d}")
 
     def test_deserialization_with_remote_db_reference(self):
-        with mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.exec"
-        ) as url_selector_exec, mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.url_dict"
-        ) as url_selector_url_dict:
+        with (
+            mock.patch("spine_items.data_connection.data_connection.UrlSelectorDialog.exec") as url_selector_exec,
+            mock.patch(
+                "spine_items.data_connection.data_connection.UrlSelectorDialog.url_dict"
+            ) as url_selector_url_dict,
+        ):
             # Add nothing
             url_selector_exec.return_value = QDialog.DialogCode.Accepted
             url_selector_url_dict.return_value = {
@@ -486,11 +489,12 @@ class TestDataConnectionWithProject(unittest.TestCase):
     def test_deserialization_with_sqlite_db_reference_in_project_directory(self):
         db_path = Path(self._temp_dir.name, "db.sqlite")
         create_new_spine_database("sqlite:///" + str(db_path))
-        with mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.exec"
-        ) as url_selector_exec, mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.url_dict"
-        ) as url_selector_url_dict:
+        with (
+            mock.patch("spine_items.data_connection.data_connection.UrlSelectorDialog.exec") as url_selector_exec,
+            mock.patch(
+                "spine_items.data_connection.data_connection.UrlSelectorDialog.url_dict"
+            ) as url_selector_url_dict,
+        ):
             # Add nothing
             url_selector_exec.return_value = QDialog.DialogCode.Accepted
             url_selector_url_dict.return_value = {
@@ -525,11 +529,12 @@ class TestDataConnectionWithProject(unittest.TestCase):
     def test_sqlite_db_reference_is_marked_missing_when_db_file_is_renamed(self):
         db_path = Path(self._temp_dir.name, "db.sqlite")
         create_new_spine_database("sqlite:///" + str(db_path))
-        with mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.exec"
-        ) as url_selector_exec, mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.url_dict"
-        ) as url_selector_url_dict:
+        with (
+            mock.patch("spine_items.data_connection.data_connection.UrlSelectorDialog.exec") as url_selector_exec,
+            mock.patch(
+                "spine_items.data_connection.data_connection.UrlSelectorDialog.url_dict"
+            ) as url_selector_url_dict,
+        ):
             # Add nothing
             url_selector_exec.return_value = QDialog.DialogCode.Accepted
             url_selector_url_dict.return_value = {
@@ -564,11 +569,12 @@ class TestDataConnectionWithProject(unittest.TestCase):
     def test_refreshing_missing_sqlite_reference_resurrects_it(self):
         db_path = Path(self._temp_dir.name, "db.sqlite")
         create_new_spine_database("sqlite:///" + str(db_path))
-        with mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.exec"
-        ) as url_selector_exec, mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.url_dict"
-        ) as url_selector_url_dict:
+        with (
+            mock.patch("spine_items.data_connection.data_connection.UrlSelectorDialog.exec") as url_selector_exec,
+            mock.patch(
+                "spine_items.data_connection.data_connection.UrlSelectorDialog.url_dict"
+            ) as url_selector_url_dict,
+        ):
             # Add nothing
             url_selector_exec.return_value = QDialog.DialogCode.Accepted
             url_selector_url_dict.return_value = {
@@ -617,11 +623,12 @@ class TestDataConnectionWithProject(unittest.TestCase):
 
     def test_broken_sqlite_url_marks_the_reference_missing(self):
         db_path = Path(self._temp_dir.name, "db.sqlite")
-        with mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.exec"
-        ) as url_selector_exec, mock.patch(
-            "spine_items.data_connection.data_connection.UrlSelectorDialog.url_dict"
-        ) as url_selector_url_dict:
+        with (
+            mock.patch("spine_items.data_connection.data_connection.UrlSelectorDialog.exec") as url_selector_exec,
+            mock.patch(
+                "spine_items.data_connection.data_connection.UrlSelectorDialog.url_dict"
+            ) as url_selector_url_dict,
+        ):
             # Add nothing
             url_selector_exec.return_value = QDialog.DialogCode.Accepted
             url_selector_url_dict.return_value = {

--- a/tests/importer/test_importer_icon.py
+++ b/tests/importer/test_importer_icon.py
@@ -31,8 +31,8 @@ class TestImporterIcon(unittest.TestCase):
         self._temp_dir = TemporaryDirectory()
         self._toolbox = create_toolboxui_with_project(self._temp_dir.name)
         item_dict = {"type": "Importer", "description": "", "x": 0, "y": 0, "specification": None}
-        exp = ImporterFactory.make_item("I", item_dict, self._toolbox, self._toolbox.project)
-        self._toolbox.project.add_item(exp)
+        exp = ImporterFactory.make_item("I", item_dict, self._toolbox, self._toolbox.project())
+        self._toolbox.project().add_item(exp)
 
     def tearDown(self):
         super().tearDown()
@@ -40,7 +40,7 @@ class TestImporterIcon(unittest.TestCase):
         self._temp_dir.cleanup()
 
     def test_mouse_double_click_event(self):
-        icon = self._toolbox.project._project_items["I"].get_icon()
+        icon = self._toolbox.project()._project_items["I"].get_icon()
         with mock.patch("spine_items.importer.importer.Importer.open_import_editor") as mock_open_import_editor:
             mock_open_import_editor.return_value = True
             icon.mouseDoubleClickEvent(QGraphicsSceneMouseEvent(QEvent.Type.GraphicsSceneMouseDoubleClick))

--- a/tests/importer/test_importer_icon.py
+++ b/tests/importer/test_importer_icon.py
@@ -31,8 +31,8 @@ class TestImporterIcon(unittest.TestCase):
         self._temp_dir = TemporaryDirectory()
         self._toolbox = create_toolboxui_with_project(self._temp_dir.name)
         item_dict = {"type": "Importer", "description": "", "x": 0, "y": 0, "specification": None}
-        exp = ImporterFactory.make_item("I", item_dict, self._toolbox, self._toolbox.project())
-        self._toolbox.project().add_item(exp)
+        exp = ImporterFactory.make_item("I", item_dict, self._toolbox, self._toolbox.project)
+        self._toolbox.project.add_item(exp)
 
     def tearDown(self):
         super().tearDown()
@@ -40,7 +40,7 @@ class TestImporterIcon(unittest.TestCase):
         self._temp_dir.cleanup()
 
     def test_mouse_double_click_event(self):
-        icon = self._toolbox.project()._project_items["I"].get_icon()
+        icon = self._toolbox.project._project_items["I"].get_icon()
         with mock.patch("spine_items.importer.importer.Importer.open_import_editor") as mock_open_import_editor:
             mock_open_import_editor.return_value = True
             icon.mouseDoubleClickEvent(QGraphicsSceneMouseEvent(QEvent.Type.GraphicsSceneMouseDoubleClick))

--- a/tests/merger/test_merger_icon.py
+++ b/tests/merger/test_merger_icon.py
@@ -29,8 +29,8 @@ class TestMergerIcon(unittest.TestCase):
         self._temp_dir = TemporaryDirectory()
         self._toolbox = create_toolboxui_with_project(self._temp_dir.name)
         item_dict = {"type": "Merger", "description": "", "x": 0, "y": 0}
-        merger = MergerFactory.make_item("M", item_dict, self._toolbox, self._toolbox.project())
-        self._toolbox.project().add_item(merger)
+        merger = MergerFactory.make_item("M", item_dict, self._toolbox, self._toolbox.project)
+        self._toolbox.project.add_item(merger)
 
     def tearDown(self):
         super().tearDown()
@@ -38,7 +38,7 @@ class TestMergerIcon(unittest.TestCase):
         self._temp_dir.cleanup()
 
     def test_animation(self):
-        icon = self._toolbox.project()._project_items["M"].get_icon()
+        icon = self._toolbox.project._project_items["M"].get_icon()
         icon.start_animation()
         icon.stop_animation()
 

--- a/tests/merger/test_merger_icon.py
+++ b/tests/merger/test_merger_icon.py
@@ -29,8 +29,8 @@ class TestMergerIcon(unittest.TestCase):
         self._temp_dir = TemporaryDirectory()
         self._toolbox = create_toolboxui_with_project(self._temp_dir.name)
         item_dict = {"type": "Merger", "description": "", "x": 0, "y": 0}
-        merger = MergerFactory.make_item("M", item_dict, self._toolbox, self._toolbox.project)
-        self._toolbox.project.add_item(merger)
+        merger = MergerFactory.make_item("M", item_dict, self._toolbox, self._toolbox.project())
+        self._toolbox.project().add_item(merger)
 
     def tearDown(self):
         super().tearDown()
@@ -38,7 +38,7 @@ class TestMergerIcon(unittest.TestCase):
         self._temp_dir.cleanup()
 
     def test_animation(self):
-        icon = self._toolbox.project._project_items["M"].get_icon()
+        icon = self._toolbox.project()._project_items["M"].get_icon()
         icon.start_animation()
         icon.stop_animation()
 

--- a/tests/mock_helpers.py
+++ b/tests/mock_helpers.py
@@ -93,9 +93,11 @@ def qsettings_value_side_effect(key, defaultValue="0"):
 
 def create_toolboxui():
     """Returns ToolboxUI, where QSettings among others has been mocked."""
-    with patch("spinetoolbox.plugin_manager.PluginManager.load_installed_plugins"), patch(
-            "spinetoolbox.ui_main.QSettings.value") as mock_qsettings_value, patch(
-            "spinetoolbox.ui_main.ToolboxUI.set_app_style") as mock_set_app_style:
+    with (
+        patch("spinetoolbox.plugin_manager.PluginManager.load_installed_plugins"),
+        patch("spinetoolbox.ui_main.QSettings.value") as mock_qsettings_value,
+        patch("spinetoolbox.ui_main.ToolboxUI.set_app_style") as mock_set_app_style,
+    ):
         mock_qsettings_value.side_effect = qsettings_value_side_effect
         mock_set_app_style.return_value = True
         toolbox = ToolboxUI()
@@ -104,22 +106,26 @@ def create_toolboxui():
 
 def create_project(toolbox, project_dir):
     """Creates a project for the given ToolboxUI."""
-    with patch("spinetoolbox.ui_main.ToolboxUI.update_recent_projects"), patch(
-        "spinetoolbox.ui_main.QSettings.setValue"
-    ), patch("spinetoolbox.ui_main.QSettings.sync"):
+    with (
+        patch("spinetoolbox.ui_main.ToolboxUI.update_recent_projects"),
+        patch("spinetoolbox.ui_main.QSettings.setValue"),
+        patch("spinetoolbox.ui_main.QSettings.sync"),
+    ):
         toolbox.create_project(project_dir)
 
 
 def create_toolboxui_with_project(project_dir):
     """Returns ToolboxUI with a project instance where
     QSettings among others has been mocked."""
-    with patch("spinetoolbox.ui_main.ToolboxUI.save_project"), patch(
-            "spinetoolbox.ui_main.QSettings.value") as mock_qsettings_value, patch(
-            "spinetoolbox.ui_main.ToolboxUI.set_app_style") as mock_set_app_style, patch(
-            "spinetoolbox.ui_main.QSettings.setValue"), patch(
-            "spinetoolbox.ui_main.QSettings.sync"), patch(
-            "spinetoolbox.plugin_manager.PluginManager.load_installed_plugins"), patch(
-            "spinetoolbox.ui_main.QScrollArea.setWidget"):
+    with (
+        patch("spinetoolbox.ui_main.ToolboxUI.save_project"),
+        patch("spinetoolbox.ui_main.QSettings.value") as mock_qsettings_value,
+        patch("spinetoolbox.ui_main.ToolboxUI.set_app_style") as mock_set_app_style,
+        patch("spinetoolbox.ui_main.QSettings.setValue"),
+        patch("spinetoolbox.ui_main.QSettings.sync"),
+        patch("spinetoolbox.plugin_manager.PluginManager.load_installed_plugins"),
+        patch("spinetoolbox.ui_main.QScrollArea.setWidget"),
+    ):
         mock_qsettings_value.side_effect = qsettings_value_side_effect
         mock_set_app_style.return_value = True
         toolbox = ToolboxUI()

--- a/tests/tool/test_tool_instance.py
+++ b/tests/tool/test_tool_instance.py
@@ -76,9 +76,11 @@ class TestToolInstance(unittest.TestCase):
     def test_julia_prepare_with_jupyter_console(self):
         # No cmd line args
         instance = self._make_julia_tool_instance(True)
-        with mock.patch("spine_items.tool.tool_instance.KernelExecutionManager") as mock_kem, mock.patch(
-            "os.path.isfile"
-        ) as mock_isfile, mock.patch("spine_items.tool.utils.custom_find_kernel_specs") as mock_find_kernel_specs:
+        with (
+            mock.patch("spine_items.tool.tool_instance.KernelExecutionManager") as mock_kem,
+            mock.patch("os.path.isfile") as mock_isfile,
+            mock.patch("spine_items.tool.utils.custom_find_kernel_specs") as mock_find_kernel_specs,
+        ):
             mock_find_kernel_specs.return_value = {"some_julia_kernel": Path(__file__).parent / "dummy_julia_kernel"}
             mock_isfile.return_value = False
             instance.prepare([])
@@ -89,9 +91,11 @@ class TestToolInstance(unittest.TestCase):
             self.assertEqual(mock_kem.call_args[0][2], ['cd("path/");', 'include("hello.jl")'])  # commands
         # With tool cmd line args
         instance = self._make_julia_tool_instance(True)
-        with mock.patch("spine_items.tool.tool_instance.KernelExecutionManager") as mock_kem, mock.patch(
-            "os.path.isfile"
-        ) as mock_isfile, mock.patch("spine_items.tool.utils.custom_find_kernel_specs") as mock_find_kernel_specs:
+        with (
+            mock.patch("spine_items.tool.tool_instance.KernelExecutionManager") as mock_kem,
+            mock.patch("os.path.isfile") as mock_isfile,
+            mock.patch("spine_items.tool.utils.custom_find_kernel_specs") as mock_find_kernel_specs,
+        ):
             mock_find_kernel_specs.return_value = {"some_julia_kernel": Path(__file__).parent / "dummy_julia_kernel"}
             mock_isfile.return_value = False
             instance.prepare(["arg1", "arg2"])
@@ -105,9 +109,11 @@ class TestToolInstance(unittest.TestCase):
             )
         # With tool and tool spec cmd line args
         instance = self._make_julia_tool_instance(True, ["arg3"])
-        with mock.patch("spine_items.tool.tool_instance.KernelExecutionManager") as mock_kem, mock.patch(
-            "os.path.isfile"
-        ) as mock_isfile, mock.patch("spine_items.tool.utils.custom_find_kernel_specs") as mock_find_kernel_specs:
+        with (
+            mock.patch("spine_items.tool.tool_instance.KernelExecutionManager") as mock_kem,
+            mock.patch("os.path.isfile") as mock_isfile,
+            mock.patch("spine_items.tool.utils.custom_find_kernel_specs") as mock_find_kernel_specs,
+        ):
             mock_find_kernel_specs.return_value = {"some_julia_kernel": Path(__file__).parent / "dummy_julia_kernel"}
             mock_isfile.return_value = False
             instance.prepare(["arg1", "arg2"])
@@ -124,9 +130,11 @@ class TestToolInstance(unittest.TestCase):
         # No cmd line args
         instance = self._make_julia_tool_instance(False)
         instance._owner.options = {"julia_sysimage": "path/to/sysimage.so"}
-        with mock.patch("spine_items.tool.tool_instance.JuliaPersistentExecutionManager") as mock_manager, mock.patch(
-            "os.path.isfile"
-        ) as mock_isfile, mock.patch("spine_items.tool.utils.resolve_julia_executable") as mock_resolve_julia:
+        with (
+            mock.patch("spine_items.tool.tool_instance.JuliaPersistentExecutionManager") as mock_manager,
+            mock.patch("os.path.isfile") as mock_isfile,
+            mock.patch("spine_items.tool.utils.resolve_julia_executable") as mock_resolve_julia,
+        ):
             mock_isfile.return_value = True  # Make isfile() accept fake julia_sysimage path
             mock_manager.return_value = True
             mock_resolve_julia.return_value = "path/to/julia"
@@ -141,9 +149,11 @@ class TestToolInstance(unittest.TestCase):
             self.assertEqual("julia hello.jl", mock_manager.call_args[0][3])  # alias
         # With tool cmd line args
         instance = self._make_julia_tool_instance(False)
-        with mock.patch("spine_items.tool.tool_instance.JuliaPersistentExecutionManager") as mock_manager, mock.patch(
-            "os.path.isfile"
-        ) as mock_isfile, mock.patch("spine_items.tool.utils.resolve_julia_executable") as mock_resolve_julia:
+        with (
+            mock.patch("spine_items.tool.tool_instance.JuliaPersistentExecutionManager") as mock_manager,
+            mock.patch("os.path.isfile") as mock_isfile,
+            mock.patch("spine_items.tool.utils.resolve_julia_executable") as mock_resolve_julia,
+        ):
             mock_isfile.return_value = False
             mock_manager.return_value = True
             mock_resolve_julia.return_value = "path/to/julia"
@@ -159,9 +169,11 @@ class TestToolInstance(unittest.TestCase):
             self.assertEqual("julia hello.jl arg1 arg2", mock_manager.call_args[0][3])  # alias
         # With tool and tool spec cmd line args
         instance = self._make_julia_tool_instance(False, ["arg3"])
-        with mock.patch("spine_items.tool.tool_instance.JuliaPersistentExecutionManager") as mock_manager, mock.patch(
-            "os.path.isfile"
-        ) as mock_isfile, mock.patch("spine_items.tool.utils.resolve_julia_executable") as mock_resolve_julia:
+        with (
+            mock.patch("spine_items.tool.tool_instance.JuliaPersistentExecutionManager") as mock_manager,
+            mock.patch("os.path.isfile") as mock_isfile,
+            mock.patch("spine_items.tool.utils.resolve_julia_executable") as mock_resolve_julia,
+        ):
             mock_isfile.return_value = False
             mock_manager.return_value = True
             mock_resolve_julia.return_value = "path/to/julia"
@@ -179,9 +191,10 @@ class TestToolInstance(unittest.TestCase):
     def test_prepare_sysimg_maker(self):
         instance = self._make_julia_tool_instance(False)
         instance._settings = FakeQSettings()
-        with mock.patch("spine_items.tool.tool_instance.ProcessExecutionManager") as mock_pem, mock.patch(
-            "spine_items.tool.utils.resolve_julia_executable"
-        ) as mock_resolve_julia:
+        with (
+            mock.patch("spine_items.tool.tool_instance.ProcessExecutionManager") as mock_pem,
+            mock.patch("spine_items.tool.utils.resolve_julia_executable") as mock_resolve_julia,
+        ):
             mock_resolve_julia.return_value = "path/to/julia"
             instance.prepare([])
             mock_pem.assert_called_once()
@@ -203,9 +216,10 @@ class TestToolInstance(unittest.TestCase):
         # No cmd line args
         instance = self._make_gams_tool_instance()
         path_to_gams = "path/to/gams"
-        with mock.patch("spine_items.tool.tool_instance.ProcessExecutionManager") as mock_manager, mock.patch(
-            "spine_items.tool.tool_instance.resolve_gams_executable"
-        ) as mock_gams_exe:
+        with (
+            mock.patch("spine_items.tool.tool_instance.ProcessExecutionManager") as mock_manager,
+            mock.patch("spine_items.tool.tool_instance.resolve_gams_executable") as mock_gams_exe,
+        ):
             mock_manager.return_value = True
             mock_gams_exe.return_value = path_to_gams
             instance.prepare([])
@@ -219,9 +233,10 @@ class TestToolInstance(unittest.TestCase):
         # With tool cmd line args
         instance = self._make_gams_tool_instance()
         path_to_gams = "path/to/gams"
-        with mock.patch("spine_items.tool.tool_instance.ProcessExecutionManager") as mock_manager, mock.patch(
-            "spine_items.tool.tool_instance.resolve_gams_executable"
-        ) as mock_gams_exe:
+        with (
+            mock.patch("spine_items.tool.tool_instance.ProcessExecutionManager") as mock_manager,
+            mock.patch("spine_items.tool.tool_instance.resolve_gams_executable") as mock_gams_exe,
+        ):
             mock_manager.return_value = True
             mock_gams_exe.return_value = path_to_gams
             instance.prepare(["arg1", "arg2"])
@@ -237,9 +252,10 @@ class TestToolInstance(unittest.TestCase):
         # With tool and tool spec cmd line args
         instance = self._make_gams_tool_instance(tool_spec_args=["arg3"])
         path_to_gams = "path/to/gams"
-        with mock.patch("spine_items.tool.tool_instance.ProcessExecutionManager") as mock_manager, mock.patch(
-            "spine_items.tool.tool_instance.resolve_gams_executable"
-        ) as mock_gams_exe:
+        with (
+            mock.patch("spine_items.tool.tool_instance.ProcessExecutionManager") as mock_manager,
+            mock.patch("spine_items.tool.tool_instance.resolve_gams_executable") as mock_gams_exe,
+        ):
             mock_manager.return_value = True
             mock_gams_exe.return_value = path_to_gams
             instance.prepare(["arg1", "arg2"])
@@ -259,9 +275,11 @@ class TestToolInstance(unittest.TestCase):
         # when os.path.isfile fails, we throw a RuntimeError
         self.assertRaises(RuntimeError, instance.prepare, ["arg1", "arg2"])
         # Test when sys.platform is win32
-        with mock.patch("spine_items.tool.tool_instance.ProcessExecutionManager") as mock_manager, mock.patch(
-            "os.path.isfile"
-        ) as mock_isfile, mock.patch("sys.platform", "win32"):
+        with (
+            mock.patch("spine_items.tool.tool_instance.ProcessExecutionManager") as mock_manager,
+            mock.patch("os.path.isfile") as mock_isfile,
+            mock.patch("sys.platform", "win32"),
+        ):
             mock_isfile.return_value = True
             mock_manager.return_value = True
             instance.prepare(["arg1", "arg2"])  # With tool cmd line args
@@ -277,9 +295,11 @@ class TestToolInstance(unittest.TestCase):
             self.assertEqual("path/program.exe", instance.program)
             self.assertEqual(0, len(instance.args))
         # Test when sys.platform is linux
-        with mock.patch("spine_items.tool.tool_instance.ProcessExecutionManager") as mock_manager, mock.patch(
-            "os.path.isfile"
-        ) as mock_isfile, mock.patch("sys.platform", "linux"):
+        with (
+            mock.patch("spine_items.tool.tool_instance.ProcessExecutionManager") as mock_manager,
+            mock.patch("os.path.isfile") as mock_isfile,
+            mock.patch("sys.platform", "linux"),
+        ):
             instance = self._make_executable_tool_instance(tool_spec_args=["arg3"])
             mock_isfile.return_value = True
             mock_manager.return_value = True

--- a/tests/tool/widgets/test_toolSpecificationEditorWindow.py
+++ b/tests/tool/widgets/test_toolSpecificationEditorWindow.py
@@ -73,11 +73,12 @@ class TestToolSpecificationEditorWindow(unittest.TestCase):
                 self.tool_specification_widget = ToolSpecificationEditorWindow(self.toolbox)
                 mock_restore_ui.assert_called()
         else:
-            with mock.patch(
-                "spinetoolbox.project_item.specification_editor_window.restore_ui"
-            ) as mock_restore_ui, mock.patch(
-                "spine_items.tool.tool_specifications.ToolSpecification._includes_main_path_relative"
-            ) as mock_impr:
+            with (
+                mock.patch("spinetoolbox.project_item.specification_editor_window.restore_ui") as mock_restore_ui,
+                mock.patch(
+                    "spine_items.tool.tool_specifications.ToolSpecification._includes_main_path_relative"
+                ) as mock_impr,
+            ):
                 mock_impr.return_value = ""
                 self.tool_specification_widget = ToolSpecificationEditorWindow(self.toolbox, spec)
                 mock_restore_ui.assert_called()
@@ -369,9 +370,10 @@ class TestToolSpecificationEditorWindow(unittest.TestCase):
         python_tool_spec.init_execution_settings()  # Sets defaults
         python_tool_spec.execution_settings["use_jupyter_console"] = True
         python_tool_spec.execution_settings["kernel_spec_name"] = "unknown_kernel"
-        with mock.patch(
-            "spine_items.tool.widgets.tool_spec_optional_widgets.KernelFetcher", new=FakeKernelFetcher
-        ), mock.patch("spine_items.tool.widgets.tool_spec_optional_widgets.Notification") as mock_notify:
+        with (
+            mock.patch("spine_items.tool.widgets.tool_spec_optional_widgets.KernelFetcher", new=FakeKernelFetcher),
+            mock.patch("spine_items.tool.widgets.tool_spec_optional_widgets.Notification") as mock_notify,
+        ):
             self.make_tool_spec_editor(python_tool_spec)
             opt_widget = self.tool_specification_widget.optional_widget
             self.assertTrue(opt_widget.ui.radioButton_jupyter_console.isChecked())


### PR DESCRIPTION
Fixes spine-tools/Spine-Toolbox#3012 partly. A second PR is needed on Toolbox side.

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
