### PR TITLE
Fix issues with Importer's source selector dialog

### DIFF
--- a/tests/data_transformer/test_DataTransformer.py
+++ b/tests/data_transformer/test_DataTransformer.py
@@ -24,7 +24,7 @@ from spine_items.data_transformer.filter_config_path import filter_config_path
 from spine_items.data_transformer.item_info import ItemInfo
 from spine_items.data_transformer.settings import EntityClassRenamingSettings
 from spinedb_api import append_filter_config
-from ..mock_helpers import create_mock_project, create_mock_toolbox, mock_finish_project_item_construction
+from tests.mock_helpers import create_mock_project, create_mock_toolbox, mock_finish_project_item_construction
 
 
 class TestDataTransformer(unittest.TestCase):

--- a/tests/exporter/test_Exporter.py
+++ b/tests/exporter/test_Exporter.py
@@ -26,7 +26,7 @@ from spine_items.exporter.specification import OutputFormat, Specification
 from spine_items.utils import database_label
 from spinedb_api import create_new_spine_database
 from spinetoolbox.project_item.logging_connection import LoggingConnection
-from ..mock_helpers import (
+from tests.mock_helpers import (
     clean_up_toolbox,
     create_mock_project,
     create_mock_toolbox,

--- a/tests/exporter/widgets/test_specification_editor_window.py
+++ b/tests/exporter/widgets/test_specification_editor_window.py
@@ -22,7 +22,7 @@ from spine_items.exporter.widgets.specification_editor_window import Specificati
 from spinedb_api.export_mapping.export_mapping import EntityClassMapping, FixedValueMapping
 from spinedb_api.export_mapping.export_mapping import from_dict as mappings_from_dict
 from spinedb_api.mapping import Position, unflatten
-from ...mock_helpers import clean_up_toolbox, create_toolboxui_with_project
+from tests.mock_helpers import clean_up_toolbox, create_toolboxui_with_project
 
 
 class TestSpecificationEditorWindow(unittest.TestCase):

--- a/tests/importer/test_Importer.py
+++ b/tests/importer/test_Importer.py
@@ -23,7 +23,7 @@ from spine_items.importer.importer import Importer
 from spine_items.importer.importer_factory import ImporterFactory
 from spine_items.importer.importer_specification import ImporterSpecification
 from spine_items.importer.item_info import ItemInfo
-from ..mock_helpers import create_mock_project, create_mock_toolbox, mock_finish_project_item_construction
+from tests.mock_helpers import create_mock_project, create_mock_toolbox, mock_finish_project_item_construction
 
 
 class TestImporter(unittest.TestCase):

--- a/tests/importer/widgets/test_ImportPreview_Window.py
+++ b/tests/importer/widgets/test_ImportPreview_Window.py
@@ -34,6 +34,7 @@ class TestImportEditorWindow(unittest.TestCase):
         toolbox.qsettings = mock.MagicMock(return_value=QSettings(toolbox))
         toolbox.restore_and_activate = mock.MagicMock()
         widget = ImportEditorWindow(toolbox, spec)
+        QApplication.processEvents()  # Let QTimer call ImportEditorWindow.start_ui().
         widget._app_settings = mock.NonCallableMagicMock()
         widget.close()
         widget._app_settings.beginGroup.assert_called_once_with("mappingPreviewWindow")

--- a/tests/importer/widgets/test_import_editor_window.py
+++ b/tests/importer/widgets/test_import_editor_window.py
@@ -48,6 +48,7 @@ class TestImportEditorWindow(unittest.TestCase):
         with mock.patch("spine_items.importer.widgets.import_editor_window.QDialog.exec") as exec_dialog:
             exec_dialog.return_value = QDialog.DialogCode.Accepted
             editor = ImportEditorWindow(self._toolbox, None)
+            QApplication.processEvents()  # Let QTimer call ImportEditorWindow.start_ui()
             exec_dialog.assert_called_once()
             exec_dialog.reset_mock()
             connector = editor._get_connector("mysql://server.com/db")


### PR DESCRIPTION
- If souce type stored in the mapping clashes with source type, user now gets a warning before seeing the source selector.
- In the above case and if user chooses a different source type to what is defined in the mapping, the undo stack is marked as dirty so it is actually possible to save the specification afterwards.
- The source selector dialog is now shown only after the specification window is shown. This enables showing correct icon in the dialog as well.

No associated issue

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
