### PR TITLE
Fix Data Store renaming

### DIFF
--- a/spine_items/data_store/data_store.py
+++ b/spine_items/data_store/data_store.py
@@ -505,7 +505,7 @@ class DataStore(ProjectItem):
         # If dialect is sqlite and db line edit refers to a file in the old data_dir, db line edit needs updating
         if self._url["dialect"] == "sqlite":
             db_dir, db_filename = os.path.split(os.path.abspath(self._url["database"].strip()))
-            if db_dir == os.path.normcase(old_data_dir):
+            if os.path.normcase(db_dir) == os.path.normcase(old_data_dir):
                 database = os.path.join(self.data_dir, db_filename)  # NOTE: data_dir has been updated at this point
                 # Check that the db was moved successfully to the new data_dir
                 if os.path.exists(database):


### PR DESCRIPTION
This fixes a bug where Data Store's SQLite path was pointing to the previous directory after the item was renamed if the database file was in the item's data directory.

Fixes spine-tools/Spine-Toolbox#3055
## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
