### PR TITLE
Fix cancelling on error in Importer

### DIFF
--- a/spine_items/importer/do_work.py
+++ b/spine_items/importer/do_work.py
@@ -67,7 +67,7 @@ def do_work(
         parsed_table_mappings = _parse_mappings(table_mappings)
         try:
             parsed_table_mappings = reader.resolve_values_for_fixed_position_mappings(
-                parsed_table_mappings, table_options
+                parsed_table_mappings, table_options, cancel_on_error
             )
         except ReaderError as error:
             logger.msg_error.emit(f"Failed to read fixed position data in {source_anchor}: {error}")


### PR DESCRIPTION
Not finding the table of a fixed target mapping does not anymore cause Importer to fail when "Cancel on error" is not set.

Re spine-tools/Spine-Database-API#506

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
