### PR TITLE
Use UTF-8 encofing for Importer's log file

### DIFF
--- a/spine_items/importer/do_work.py
+++ b/spine_items/importer/do_work.py
@@ -173,7 +173,7 @@ def _import_data_to_url(cancel_on_error, on_conflict, logs_dir, all_data, client
         # Log errors in a time stamped file into the logs directory
         timestamp = create_log_file_timestamp()
         logfilepath = os.path.abspath(os.path.join(logs_dir, timestamp + "_import_error.log"))
-        with open(logfilepath, "w") as f:
+        with open(logfilepath, "w", encoding="utf-8") as f:
             for err in all_import_errors:
                 f.write(str(err) + "\n")
         # Make error log file anchor with path as tooltip


### PR DESCRIPTION
Otherwise writing the file may Traceback if the error messages contain special characters.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
