### PR TITLE
Support changing Tool results directory

### DIFF
--- a/spine_items/commands.py
+++ b/spine_items/commands.py
@@ -164,3 +164,29 @@ class UpdateRootDirCommand(SpineToolboxCommand):
     def undo(self):
         item = self._project.get_item(self._item_name)
         item.do_set_root_directory(self._undo_root_dir)
+
+
+class UpdateResultDirCommand(SpineToolboxCommand):
+    def __init__(self, item_name, result_dir, project):
+        """Command to update Tool result directory.
+
+        Args:
+            item_name (str): Item's name
+            result_dir (str): Result directory
+            project (SpineToolboxProject): Project
+        """
+        super().__init__()
+        self._item_name = item_name
+        self._redo_result_dir = result_dir
+        item = project.get_item(item_name)
+        self._undo_result_dir = item._options.get("output_directory")
+        self._project = project
+        self.setText(f"change result directory of {item_name}")
+
+    def redo(self):
+        item = self._project.get_item(self._item_name)
+        item.do_set_result_directory(self._redo_result_dir)
+
+    def undo(self):
+        item = self._project.get_item(self._item_name)
+        item.do_set_result_directory(self._undo_result_dir)

--- a/spine_items/tool/executable_item.py
+++ b/spine_items/tool/executable_item.py
@@ -35,6 +35,7 @@ from spine_engine.utils.helpers import (
     resolve_julia_executable,
     write_filter_id_file,
 )
+from spine_engine.utils.serialization import deserialize_path
 from ..db_writer_executable_item_base import DBWriterExecutableItemBase
 from ..utils import generate_filter_subdirectory_name
 from .item_info import ItemInfo
@@ -78,7 +79,7 @@ class ExecutableItem(DBWriterExecutableItemBase):
         """
         super().__init__(name, project_dir, logger, group_id=group_id)
         self._work_dir = work_dir
-        output_dir = options.get("output_directory")
+        output_dir = deserialize_path(options.get("output_directory"), project_dir)
         self._output_dir = str(pathlib.Path(self._data_dir, TOOL_OUTPUT_DIR)) if not output_dir else output_dir
         self._tool_specification = tool_specification
         self._cmd_line_args = cmd_line_args

--- a/spine_items/tool/executable_item.py
+++ b/spine_items/tool/executable_item.py
@@ -78,7 +78,8 @@ class ExecutableItem(DBWriterExecutableItemBase):
         """
         super().__init__(name, project_dir, logger, group_id=group_id)
         self._work_dir = work_dir
-        self._output_dir = str(pathlib.Path(self._data_dir, TOOL_OUTPUT_DIR))
+        output_dir = options.get("output_directory")
+        self._output_dir = str(pathlib.Path(self._data_dir, TOOL_OUTPUT_DIR)) if not output_dir else output_dir
         self._tool_specification = tool_specification
         self._cmd_line_args = cmd_line_args
         self._options = options
@@ -592,37 +593,37 @@ class ExecutableItem(DBWriterExecutableItemBase):
             forward_resources (Iterable of ProjectItemResource): forward resources
             execution_dir (str): path to the execution directory
         """
-        if filter_id:
-            filter_output_dir = os.path.join(
-                self._output_dir, generate_filter_subdirectory_name(forward_resources, self.hash_filter_id())
-            )
-            try:
-                os.makedirs(filter_output_dir, exist_ok=True)
-                self._output_dir = filter_output_dir
-            except OSError:
-                self._logger.msg_error.emit(f"[OSError] Creating directory <b>{filter_output_dir}</b> failed.")
-        output_dir_timestamp = _create_output_dir_timestamp()  # Get timestamp when tool finished
-        # Create an output folder with timestamp and copy output directly there
-        if return_code != 0:
-            result_path = os.path.abspath(os.path.join(self._output_dir, "failed", output_dir_timestamp))
-        else:
-            result_path = os.path.abspath(os.path.join(self._output_dir, output_dir_timestamp))
-        try:
-            os.makedirs(result_path, exist_ok=True)
-        except OSError:
-            self._logger.msg_error.emit(
-                "\tError creating timestamped output directory. "
-                "Tool specification output files not copied. Please check directory permissions."
-            )
-            return
-        # Make link to output folder
-        result_anchor = (
-            f"<a style='color:#BB99FF;' title='{result_path}' href='file:///{result_path}'>results directory</a>"
-        )
-        if filter_id:
-            write_filter_id_file(filter_id, os.path.dirname(result_path))
-        self._logger.msg.emit(f"*** Archiving output files to {result_anchor} ***")
         if self._tool_specification.outputfiles:
+            if filter_id:
+                filter_output_dir = os.path.join(
+                    self._output_dir, generate_filter_subdirectory_name(forward_resources, self.hash_filter_id())
+                )
+                try:
+                    os.makedirs(filter_output_dir, exist_ok=True)
+                    self._output_dir = filter_output_dir
+                except OSError:
+                    self._logger.msg_error.emit(f"[OSError] Creating directory <b>{filter_output_dir}</b> failed.")
+            output_dir_timestamp = _create_output_dir_timestamp()  # Get timestamp when tool finished
+            # Create an output folder with timestamp and copy output directly there
+            if return_code != 0:
+                result_path = os.path.abspath(os.path.join(self._output_dir, "failed", output_dir_timestamp))
+            else:
+                result_path = os.path.abspath(os.path.join(self._output_dir, output_dir_timestamp))
+            try:
+                os.makedirs(result_path, exist_ok=True)
+            except OSError:
+                self._logger.msg_error.emit(
+                    "\tError creating timestamped output directory. "
+                    "Tool specification output files not copied. Please check directory permissions."
+                )
+                return
+            # Make link to output folder
+            result_anchor = (
+                f"<a style='color:#BB99FF;' title='{result_path}' href='file:///{result_path}'>results directory</a>"
+            )
+            if filter_id:
+                write_filter_id_file(filter_id, os.path.dirname(result_path))
+            self._logger.msg.emit(f"*** Archiving output files to {result_anchor} ***")
             saved_files, failed_files = self._copy_output_files(result_path, execution_dir)
             if not saved_files:
                 # If no files were saved
@@ -641,11 +642,11 @@ class ExecutableItem(DBWriterExecutableItemBase):
                 self._logger.msg.emit(f"\t<b>{failed_files_anchor}")
         else:
             tip_anchor = (
-                "<a style='color:#99CCFF;' title='When you add output files to the Tool specification,\n "
-                "they will be archived into results directory. Also, output files are passed to\n "
-                "subsequent project items.' href='#'>Tip</a>"
+                "<a style='color:#99CCFF;' title='By adding <b>output files</b> to the Tool specification,\n "
+                "they will be archived into the results directory. In addition, <b>output files</b> will be \n"
+                "passed to subsequent project items.' href='#'>Tip</a>"
             )
-            self._logger.msg_warning.emit(f"\tNo output files defined for this Tool specification. {tip_anchor}")
+            self._logger.msg_warning.emit(f"No output files defined for this Tool specification. {tip_anchor}")
 
     def _optional_output_destination_paths(self, paths, execution_dir):
         """Returns a dictionary telling where optional output files should be copied to before execution.

--- a/spine_items/tool/tool.py
+++ b/spine_items/tool/tool.py
@@ -18,7 +18,7 @@ from spine_engine.config import TOOL_OUTPUT_DIR
 from spine_engine.project_item.project_item_resource import CmdLineArg, LabelArg, make_cmd_line_arg
 from spine_engine.utils.helpers import ExecutionDirection, resolve_julia_executable, resolve_python_interpreter
 from spine_engine.utils.serialization import deserialize_path, serialize_path
-from spinetoolbox.helpers import open_url, select_root_directory
+from spinetoolbox.helpers import open_url, select_root_directory, same_path
 from spinetoolbox.mvcmodels.file_list_models import FileListModel
 from ..commands import UpdateCmdLineArgsCommand, UpdateGroupIdCommand, UpdateRootDirCommand, UpdateResultDirCommand
 from ..db_writer_item_base import DBWriterItemBase
@@ -62,14 +62,14 @@ class Tool(DBWriterItemBase):
             x (float): Initial X coordinate of item icon
             y (float): Initial Y coordinate of item icon
             toolbox (ToolboxUI): QMainWindow instance
-            project (SpineToolboxProject): the project this item belongs to
+            project (SpineToolboxProject): The project this item belongs to
             specification_name (str): Name of this Tool's Tool specification
             execute_in_work (bool): Execute associated Tool specification in work (True) or source directory (False)
             cmd_line_args (list, optional): Tool command line arguments
-            options (dict, optional): misc tool options. At the moment it just holds the location of the Julia sysimage
-            kill_completed_processes (bool): whether to kill completed persistent processes
-            log_process_output (bool): whether to log process output to a file
-            group_id (str, optional): execution group id
+            options (dict, optional): Misc tool options
+            kill_completed_processes (bool): Whether to kill completed persistent processes
+            log_process_output (bool): Whether to log process output to a file
+            group_id (str, optional): Execution group id
             root_dir (str, optional): Root directory for the Tool Spec's program
         """
         super().__init__(name, description, x, y, project)
@@ -90,10 +90,10 @@ class Tool(DBWriterItemBase):
         self._cmdline_args_model.args_updated.connect(self._push_update_cmd_line_args_command)
         self._populate_cmdline_args_model()
         self._input_file_model = FileListModel(header_label="Available resources", draggable=True)
-        output_dir = options.get("output_directory")
-        self.output_dir = os.path.join(self.data_dir, TOOL_OUTPUT_DIR) if not output_dir else output_dir
         self._specification_menu = None
         self._options = options if options is not None else {}
+        output_dir = deserialize_path(self._options.get("output_directory"), self._project.project_dir)
+        self._output_dir = self.default_output_dir if not output_dir else output_dir
         self._kill_completed_processes = kill_completed_processes
         self._log_process_output = log_process_output
         self._resources_from_upstream = []
@@ -129,6 +129,10 @@ class Tool(DBWriterItemBase):
     @property
     def root_dir(self):
         return self._root_directory
+
+    @property
+    def default_output_dir(self):
+        return os.path.join(self.data_dir, TOOL_OUTPUT_DIR)
 
     def _get_options_widget(self):
         """Returns a widget to specify the options for this tool.
@@ -230,14 +234,13 @@ class Tool(DBWriterItemBase):
         self._do_update_remove_args_button_enabled()
         self._properties_ui.lineEdit_group_id.setText(self._group_id)
         self._properties_ui.lineEdit_root_directory.setText(self._root_directory)
-        output_dir = self._options.get("output_directory")
-        if not output_dir:
+        output_dir_displayed = self._output_dir.replace("/", os.sep)
+        if same_path(self._output_dir, self.default_output_dir):
             self._properties_ui.lineEdit_result_directory.clear()
-            self._properties_ui.lineEdit_result_directory.setPlaceholderText(self.output_dir)
-            self._properties_ui.lineEdit_result_directory.setToolTip(self.output_dir)
-        else:
-            self._properties_ui.lineEdit_result_directory.setText(output_dir.replace("/", os.sep))
-            self._properties_ui.lineEdit_result_directory.setToolTip(output_dir.replace("/", os.sep))
+        else:  # Set text only if results directory is not default
+            self._properties_ui.lineEdit_result_directory.setText(output_dir_displayed)
+        self._properties_ui.lineEdit_result_directory.setPlaceholderText(output_dir_displayed)
+        self._properties_ui.lineEdit_result_directory.setToolTip(output_dir_displayed)
 
     @Slot(bool)
     def _browse_root_directory(self, _=False):
@@ -271,25 +274,26 @@ class Tool(DBWriterItemBase):
     def _set_result_directory(self):
         """Pushes a command to update result directory whenever the user edits the line edit."""
         result_dir = self._properties_ui.lineEdit_result_directory.text().strip()
-        if result_dir and self._options.get("output_directory") == result_dir:
+        if same_path(self._output_dir, result_dir):  # When user picks the same folder again
+            self._properties_ui.lineEdit_result_directory.clear()
+            return
+        if not result_dir and same_path(self._output_dir, self.default_output_dir):
             return
         self._toolbox.undo_stack.push(UpdateResultDirCommand(self.name, result_dir, self._project))
 
     def do_set_result_directory(self, result_dir):
         """Sets results directory."""
-        if not result_dir:
-            self.output_dir = os.path.join(self.data_dir, TOOL_OUTPUT_DIR)
-            self._options["output_directory"] = None
-        else:
-            self.output_dir = self._options["output_directory"] = result_dir
+        self._output_dir = self.default_output_dir if not result_dir else result_dir
+        self._options["output_directory"] = serialize_path(self._output_dir, self._project.project_dir)
         if self._active:
+            output_dir_displayed = self._output_dir.replace("/", os.sep)
             if not result_dir:
                 self._properties_ui.lineEdit_result_directory.clear()
-                self._properties_ui.lineEdit_result_directory.setPlaceholderText(self.output_dir)
+                self._properties_ui.lineEdit_result_directory.setPlaceholderText(output_dir_displayed)
             else:
-                self._properties_ui.lineEdit_result_directory.setText(self.output_dir)
-                self._properties_ui.lineEdit_result_directory.setToolTip(self.output_dir)
-            self._properties_ui.lineEdit_result_directory.setToolTip(self.output_dir)
+                self._properties_ui.lineEdit_result_directory.setText(output_dir_displayed)
+                self._properties_ui.lineEdit_result_directory.setToolTip(output_dir_displayed)
+            self._properties_ui.lineEdit_result_directory.setToolTip(output_dir_displayed)
 
     @Slot(bool)
     def show_specification_window(self, _=True):
@@ -486,14 +490,14 @@ class Tool(DBWriterItemBase):
     @Slot(bool)
     def _open_results_directory(self, _):
         """Open output directory in file browser."""
-        if not os.path.exists(self.output_dir):
+        if not os.path.exists(self._output_dir):
             self._logger.msg_warning.emit(f"Tool <b>{self.name}</b> has no results. Click Execute to generate them.")
             return
-        url = "file:///" + self.output_dir
+        url = "file:///" + self._output_dir
         # noinspection PyTypeChecker, PyCallByClass, PyArgumentList
         res = open_url(url)
         if not res:
-            self._logger.msg_error.emit(f"Failed to open directory: {self.output_dir}")
+            self._logger.msg_error.emit(f"Failed to open directory: {self._output_dir}")
 
     def specification(self):
         """Returns Tool specification."""
@@ -501,7 +505,7 @@ class Tool(DBWriterItemBase):
 
     def resources_for_direct_successors(self):
         """See base class"""
-        return scan_for_resources(self, self.specification(), self.output_dir)
+        return scan_for_resources(self, self.specification(), self._output_dir)
 
     @property
     def executable_class(self):
@@ -657,6 +661,10 @@ class Tool(DBWriterItemBase):
             d["specification"] = self.specification().name
         d["execute_in_work"] = self.execute_in_work
         d["cmd_line_args"] = [arg.to_dict() for arg in self.cmd_line_args]
+        if not same_path(self._output_dir, self.default_output_dir):
+            self._options["output_directory"] = serialize_path(self._output_dir, self._project.project_dir)
+        else:
+            self._options.pop("output_directory", None)
         if self._options:
             d["options"] = self._options
         d["kill_completed_processes"] = self._kill_completed_processes
@@ -706,8 +714,8 @@ class Tool(DBWriterItemBase):
         """See base class."""
         if not super().rename(new_name, rename_data_dir_message):
             return False
-        output_dir = self._options.get("output_directory")
-        self.output_dir = os.path.join(self.data_dir, TOOL_OUTPUT_DIR) if not output_dir else output_dir
+        output_dir = deserialize_path(self._options.get("output_directory"), self._project.project_dir)
+        self._output_dir = self.default_output_dir if not output_dir else output_dir
         return True
 
     def notify_destination(self, source_item):

--- a/spine_items/tool/ui/executable_cmd_exec_options.py
+++ b/spine_items/tool/ui/executable_cmd_exec_options.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'executable_cmd_exec_options.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.5.2
+## Created by: Qt User Interface Compiler version 6.7.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -41,8 +41,8 @@ class Ui_Form(object):
         self.verticalLayout.setContentsMargins(0, 0, 0, 0)
         self.line_3 = QFrame(Form)
         self.line_3.setObjectName(u"line_3")
-        self.line_3.setFrameShape(QFrame.HLine)
-        self.line_3.setFrameShadow(QFrame.Sunken)
+        self.line_3.setFrameShape(QFrame.Shape.HLine)
+        self.line_3.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.verticalLayout.addWidget(self.line_3)
 
@@ -76,7 +76,7 @@ class Ui_Form(object):
 
         self.comboBox_shell = QComboBox(Form)
         self.comboBox_shell.setObjectName(u"comboBox_shell")
-        sizePolicy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.comboBox_shell.sizePolicy().hasHeightForWidth())

--- a/spine_items/tool/ui/julia_kernel_spec_options.py
+++ b/spine_items/tool/ui/julia_kernel_spec_options.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'julia_kernel_spec_options.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.6.3
+## Created by: Qt User Interface Compiler version 6.7.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -42,8 +42,8 @@ class Ui_Form(object):
         self.verticalLayout_3.setContentsMargins(0, 0, 0, 0)
         self.line_3 = QFrame(Form)
         self.line_3.setObjectName(u"line_3")
-        self.line_3.setFrameShape(QFrame.HLine)
-        self.line_3.setFrameShadow(QFrame.Sunken)
+        self.line_3.setFrameShape(QFrame.Shape.HLine)
+        self.line_3.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.verticalLayout_3.addWidget(self.line_3)
 
@@ -71,8 +71,8 @@ class Ui_Form(object):
 
         self.line = QFrame(Form)
         self.line.setObjectName(u"line")
-        self.line.setFrameShape(QFrame.VLine)
-        self.line.setFrameShadow(QFrame.Sunken)
+        self.line.setFrameShape(QFrame.Shape.VLine)
+        self.line.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.horizontalLayout_3.addWidget(self.line)
 
@@ -97,7 +97,7 @@ class Ui_Form(object):
         self.toolButton_browse_julia = QToolButton(Form)
         self.toolButton_browse_julia.setObjectName(u"toolButton_browse_julia")
         icon = QIcon()
-        icon.addFile(u":/icons/folder-open-solid.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon.addFile(u":/icons/folder-open-solid.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.toolButton_browse_julia.setIcon(icon)
 
         self.horizontalLayout_2.addWidget(self.toolButton_browse_julia)
@@ -152,7 +152,7 @@ class Ui_Form(object):
         self.toolButton_refresh_kernel_specs = QToolButton(Form)
         self.toolButton_refresh_kernel_specs.setObjectName(u"toolButton_refresh_kernel_specs")
         icon1 = QIcon()
-        icon1.addFile(u":/icons/sync.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon1.addFile(u":/icons/sync.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.toolButton_refresh_kernel_specs.setIcon(icon1)
         self.toolButton_refresh_kernel_specs.setToolButtonStyle(Qt.ToolButtonIconOnly)
 

--- a/spine_items/tool/ui/julia_options.py
+++ b/spine_items/tool/ui/julia_options.py
@@ -14,7 +14,7 @@
 ################################################################################
 ## Form generated from reading UI file 'julia_options.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.5.2
+## Created by: Qt User Interface Compiler version 6.7.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -62,7 +62,7 @@ class Ui_Form(object):
         self.toolButton_new_sysimage = QToolButton(Form)
         self.toolButton_new_sysimage.setObjectName(u"toolButton_new_sysimage")
         icon = QIcon()
-        icon.addFile(u":/icons/file.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon.addFile(u":/icons/file.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.toolButton_new_sysimage.setIcon(icon)
         self.toolButton_new_sysimage.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
@@ -71,7 +71,7 @@ class Ui_Form(object):
         self.toolButton_open_sysimage = QToolButton(Form)
         self.toolButton_open_sysimage.setObjectName(u"toolButton_open_sysimage")
         icon1 = QIcon()
-        icon1.addFile(u":/icons/folder-open-solid.svg", QSize(), QIcon.Normal, QIcon.Off)
+        icon1.addFile(u":/icons/folder-open-solid.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.toolButton_open_sysimage.setIcon(icon1)
 
         self.horizontalLayout.addWidget(self.toolButton_open_sysimage)

--- a/spine_items/tool/ui/tool_properties.py
+++ b/spine_items/tool/ui/tool_properties.py
@@ -259,9 +259,18 @@ class Ui_Form(object):
 
         self.horizontalLayout_11.addWidget(self.pushButton_tool_results)
 
-        self.horizontalSpacer_6 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.lineEdit_result_directory = QLineEdit(self.frame)
+        self.lineEdit_result_directory.setObjectName(u"lineEdit_result_directory")
+        self.lineEdit_result_directory.setReadOnly(False)
+        self.lineEdit_result_directory.setClearButtonEnabled(True)
 
-        self.horizontalLayout_11.addItem(self.horizontalSpacer_6)
+        self.horizontalLayout_11.addWidget(self.lineEdit_result_directory)
+
+        self.toolButton_browse_result_directory = QToolButton(self.frame)
+        self.toolButton_browse_result_directory.setObjectName(u"toolButton_browse_result_directory")
+        self.toolButton_browse_result_directory.setIcon(icon3)
+
+        self.horizontalLayout_11.addWidget(self.toolButton_browse_result_directory)
 
 
         self.verticalLayout_2.addLayout(self.horizontalLayout_11)
@@ -286,7 +295,9 @@ class Ui_Form(object):
         QWidget.setTabOrder(self.lineEdit_group_id, self.kill_consoles_check_box)
         QWidget.setTabOrder(self.kill_consoles_check_box, self.log_process_output_check_box)
         QWidget.setTabOrder(self.log_process_output_check_box, self.pushButton_tool_results)
-        QWidget.setTabOrder(self.pushButton_tool_results, self.scrollArea)
+        QWidget.setTabOrder(self.pushButton_tool_results, self.lineEdit_result_directory)
+        QWidget.setTabOrder(self.lineEdit_result_directory, self.toolButton_browse_result_directory)
+        QWidget.setTabOrder(self.toolButton_browse_result_directory, self.scrollArea)
 
         self.retranslateUi(Form)
 
@@ -330,5 +341,12 @@ class Ui_Form(object):
         self.pushButton_tool_results.setToolTip(QCoreApplication.translate("Form", u"<html><head/><body><p>Open results archive in file browser</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.pushButton_tool_results.setText(QCoreApplication.translate("Form", u"Results...", None))
+#if QT_CONFIG(tooltip)
+        self.lineEdit_result_directory.setToolTip(QCoreApplication.translate("Form", u"<html><head/><body><p>Result directory</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.lineEdit_result_directory.setText("")
+#if QT_CONFIG(tooltip)
+        self.toolButton_browse_result_directory.setToolTip(QCoreApplication.translate("Form", u"<html><head/><body><p>Select Result directory using file browser. Leave blank to use default directory.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
     # retranslateUi
 

--- a/spine_items/tool/ui/tool_properties.ui
+++ b/spine_items/tool/ui/tool_properties.ui
@@ -419,17 +419,31 @@ QScrollArea &gt; QWidget &gt; QWidget { background: transparent; }</string>
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_6">
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+             <widget class="QLineEdit" name="lineEdit_result_directory">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Result directory&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
+              <property name="text">
+               <string/>
               </property>
-             </spacer>
+              <property name="readOnly">
+               <bool>false</bool>
+              </property>
+              <property name="clearButtonEnabled">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="toolButton_browse_result_directory">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select Result directory using file browser. Leave blank to use default directory.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../ui/resources/resources_icons.qrc">
+                <normaloff>:/icons/folder-open-solid.svg</normaloff>:/icons/folder-open-solid.svg</iconset>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
@@ -469,6 +483,8 @@ QScrollArea &gt; QWidget &gt; QWidget { background: transparent; }</string>
   <tabstop>kill_consoles_check_box</tabstop>
   <tabstop>log_process_output_check_box</tabstop>
   <tabstop>pushButton_tool_results</tabstop>
+  <tabstop>lineEdit_result_directory</tabstop>
+  <tabstop>toolButton_browse_result_directory</tabstop>
   <tabstop>scrollArea</tabstop>
  </tabstops>
  <resources>

--- a/tests/tool/test_Tool.py
+++ b/tests/tool/test_Tool.py
@@ -142,13 +142,7 @@ class TestTool(unittest.TestCase):
         """Test that specification is loaded into selections on Tool creation,
         and then shown in the ui when Tool is activated.
         """
-        options = {
-                "output_directory": {
-                    "type": "path",
-                    "relative": False,
-                    "path": "/somedir/outputs"
-                }
-            }
+        options = {"output_directory": {"type": "path", "relative": False, "path": "/somedir/outputs"}}
         item_dict = {
             "type": "Tool",
             "description": "",
@@ -166,13 +160,7 @@ class TestTool(unittest.TestCase):
 
     def test_save_and_restore_selections(self):
         """Test that selections are saved and restored when deactivating a Tool and activating it again."""
-        options = {
-                "output_directory": {
-                    "type": "path",
-                    "relative": True,
-                    "path": ".spinetoolbox/outputs"
-                }
-            }
+        options = {"output_directory": {"type": "path", "relative": True, "path": ".spinetoolbox/outputs"}}
         item_dict = {"type": "Tool", "description": "", "x": 0, "y": 0, "specification": "", "options": options}
         tool = self._add_tool(item_dict)
         expected_result_dir = os.path.abspath(os.path.join(tool._project.project_dir, ".spinetoolbox", "outputs"))

--- a/tests/tool/test_Tool.py
+++ b/tests/tool/test_Tool.py
@@ -136,12 +136,19 @@ class TestTool(unittest.TestCase):
         self.assertEqual(expected_data_dir, tool.data_dir)  # Check data dir
         # Check that output_dir has been updated
         expected_output_dir = os.path.join(tool.data_dir, TOOL_OUTPUT_DIR)
-        self.assertEqual(expected_output_dir, tool.output_dir)
+        self.assertEqual(expected_output_dir, tool._output_dir)
 
     def test_load_tool_specification(self):
         """Test that specification is loaded into selections on Tool creation,
         and then shown in the ui when Tool is activated.
         """
+        options = {
+                "output_directory": {
+                    "type": "path",
+                    "relative": False,
+                    "path": "/somedir/outputs"
+                }
+            }
         item_dict = {
             "type": "Tool",
             "description": "",
@@ -149,17 +156,26 @@ class TestTool(unittest.TestCase):
             "y": 0,
             "specification": "simple_exec",
             "execute_in_work": False,
+            "options": options,
         }
         tool = self._add_tool(item_dict)
         with mock.patch("spine_items.tool.tool.ToolSpecificationMenu") as mock_tool_spec_menu:
             mock_tool_spec_menu.side_effect = lambda *args: QMenu()
             tool.activate()
-            self._assert_is_simple_exec_tool(tool)
+            self._assert_is_simple_exec_tool(tool, "/somedir/outputs".replace("/", os.sep))
 
     def test_save_and_restore_selections(self):
         """Test that selections are saved and restored when deactivating a Tool and activating it again."""
-        item_dict = {"type": "Tool", "description": "", "x": 0, "y": 0, "specification": ""}
+        options = {
+                "output_directory": {
+                    "type": "path",
+                    "relative": True,
+                    "path": ".spinetoolbox/outputs"
+                }
+            }
+        item_dict = {"type": "Tool", "description": "", "x": 0, "y": 0, "specification": "", "options": options}
         tool = self._add_tool(item_dict)
+        expected_result_dir = os.path.abspath(os.path.join(tool._project.project_dir, ".spinetoolbox", "outputs"))
         with mock.patch("spine_items.tool.tool.ToolSpecificationMenu") as mock_tool_spec_menu:
             mock_tool_spec_menu.side_effect = lambda *args: QMenu()
             tool.activate()
@@ -167,10 +183,10 @@ class TestTool(unittest.TestCase):
             # Set the simple_exec tool specification manually
             tool._properties_ui.comboBox_tool.textActivated.emit("simple_exec")
             tool._properties_ui.radioButton_execute_in_source.setChecked(True)
-            self._assert_is_simple_exec_tool(tool)
+            self._assert_is_simple_exec_tool(tool, expected_result_dir)
             tool.deactivate()
             tool.activate()
-            self._assert_is_simple_exec_tool(tool)
+            self._assert_is_simple_exec_tool(tool, expected_result_dir)
 
     @unittest.skip("Test doesn't work on Python 3.12 on Windows")
     def test_find_input_files(self):
@@ -229,7 +245,7 @@ class TestTool(unittest.TestCase):
         self.project.get_item.return_value = tool
         return tool
 
-    def _assert_is_simple_exec_tool(self, tool):
+    def _assert_is_simple_exec_tool(self, tool, expected_result_dir=""):
         """Assert that the given tool has the simple_exec specification."""
         # Check tool spec
         source_files = tool.specification().includes
@@ -251,6 +267,8 @@ class TestTool(unittest.TestCase):
         combox_text = tool._properties_ui.comboBox_tool.currentText()
         in_work = tool._properties_ui.radioButton_execute_in_work.isChecked()
         in_source = tool._properties_ui.radioButton_execute_in_source.isChecked()
+        result_dir = tool._properties_ui.lineEdit_result_directory.text()
+        self.assertEqual(expected_result_dir, result_dir)
         self.assertEqual(combox_text, "simple_exec")
         self.assertFalse(in_work)
         self.assertTrue(in_source)


### PR DESCRIPTION
This PR adds a line edit next to the Results... button in Tool Properties, where one can change the results directory.

In addition, Tools should not make any empty result directories anymore!

Fixes spine-tools/Spine-Toolbox#1994

## todo:
- [x] Update Changelog
- [x] Update Tool Properties screenshots in User Guide

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
