### PR TITLE
Enable Pytest

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,2 @@
 coverage[toml]
+pytest >= 8

--- a/tests/data_store/test_dataStore.py
+++ b/tests/data_store/test_dataStore.py
@@ -132,7 +132,7 @@ class TestDataStoreWithToolbox(unittest.TestCase):
         self.assertEqual([], self.ds.get_icon().exclamation_icon._notifications)
         # Check that there is a warning about uncommitted changes
         db_map = self.ds.get_db_map()
-        self._toolbox.db_mngr.add_entity_classes({db_map: [{"name": "my_object_class"}]})
+        self._toolbox.db_mngr.add_items("entity_class", {db_map: [{"name": "my_object_class"}]})
         self.assertEqual(
             [f"{self.ds.name} has uncommitted changes"], self.ds.get_icon().exclamation_icon._notifications
         )


### PR DESCRIPTION
Add `pytest` to `dev-requirements.txt`. `pytest` can now be used in place of `unittest`.

> [!IMPORTANT]  
> Please let me know if you would like changes to documentation or release notes as well. Should we switch the CI to `pytest`?

Fixes #262

## Future Proofing
To keep the `pytest` compatibility, I would suggest following the [pytest naming conventions](https://docs.pytest.org/en/stable/explanation/goodpractices.html#conventions-for-python-test-discovery) for tests. For `spine-items` we are doing this already. Brief summary:

- In the `tests` directory, files are named `test_*.py` or `*_test.py`.
- Within those files, `test` prefixed test functions or methods outside of class, and `test` prefixed test functions or methods inside `Test` prefixed test classes (without an `__init__` method) are run.

Rule of thumb: Keeping `test*` prefixes to things that are supposed to be run by the testing framework.


## Other Related Issues
- https://github.com/spine-tools/Spine-Database-API/issues/535
- https://github.com/spine-tools/Spine-Toolbox/issues/3114

## Related PRs
- https://github.com/spine-tools/Spine-Database-API/pull/536
- https://github.com/spine-tools/Spine-Toolbox/pull/3115

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
