### PR TITLE
Use pytest for GitHub Actions

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -54,7 +54,7 @@ jobs:
         if [ "$RUNNER_OS" != "Windows" ]; then
           export QT_QPA_PLATFORM=offscreen
         fi
-        coverage run -m unittest discover --verbose
+        pytest tests/ --cov --verbose
       shell: bash
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v4

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,2 @@
 coverage[toml]
-pytest >= 8
+pytest-cov >= 6


### PR DESCRIPTION
This PR adds `pytest-cov` to the dev requirements and ports the GitHub CI to use pytest.

Fixes #262 

## Future Proofing
To keep the `pytest` compatibility, I would suggest following the [pytest naming conventions](https://docs.pytest.org/en/stable/explanation/goodpractices.html#conventions-for-python-test-discovery) for tests. Brief summary:

- In the `tests` directory, files are named `test_*.py` or `*_test.py`. We do that already.
- Within those files, `test` prefixed test functions or methods outside of class, and `test` prefixed test functions or methods inside `Test` prefixed test classes (without an `__init__` method) are run.

Rule of thumb: Keeping `test*` prefixes to things that are supposed to be run by the testing framework.

## Related Issues
- https://github.com/spine-tools/Spine-Toolbox/issues/3114
- https://github.com/spine-tools/spine-engine/issues/171
- https://github.com/spine-tools/Spine-Database-API/issues/535

## Related PRs
- https://github.com/spine-tools/Spine-Toolbox/pull/3115
- https://github.com/spine-tools/spine-engine/pull/172
- https://github.com/spine-tools/Spine-Database-API/pull/536

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [x] Unit tests pass
