### PR TITLE
Fix importer/exporter crash when GAMS executable version is less than 42

### DIFF
--- a/spine_items/importer/connection_manager.py
+++ b/spine_items/importer/connection_manager.py
@@ -138,25 +138,20 @@ class ConnectionManager(QObject):
             source (str): source file name or URL
             **source_extras: source specific additional connection settings
         """
-        # close existing thread
         self.close_connection()
-        # create new thread and worker
-        self._thread = QThread()
         self._worker = ConnectionWorker(self._connection, self._connection_settings, source, source_extras)
+        self._thread = QThread()
         self._worker.moveToThread(self._thread)
-        # connect worker signals
         self._worker.connectionReady.connect(self._handle_connection_ready)
         self._worker.tablesReady.connect(self._handle_tables_ready)
         self._worker.dataReady.connect(self.data_ready.emit)
         self._worker.defaultMappingReady.connect(self.default_mapping_ready.emit)
         self._worker.error.connect(self.error.emit)
         self._worker.connectionFailed.connect(self.connection_failed.emit)
-        # connect start working signals
         self.tables_requested.connect(self._worker.tables)
         self.data_requested.connect(self._worker.data)
         self.default_mapping_requested.connect(self._worker.default_mapping)
         self.connection_closed.connect(self._worker.close_connection, type=Qt.ConnectionType.BlockingQueuedConnection)
-        # when thread is started, connect worker to source
         self._thread.started.connect(self._worker.init_connection)
         self._thread.start()
 

--- a/spine_items/importer/widgets/import_editor_window.py
+++ b/spine_items/importer/widgets/import_editor_window.py
@@ -17,6 +17,7 @@ from operator import attrgetter
 import os
 from PySide6.QtCore import QItemSelectionModel, QModelIndex, Qt, QTimer, Signal, Slot
 from PySide6.QtWidgets import QDialog, QDialogButtonBox, QFileDialog, QListWidget, QMessageBox, QVBoxLayout
+from spinedb_api.exception import ReaderError
 from spinedb_api.helpers import remove_credentials_from_url
 from spinedb_api.spine_io.gdx_utils import find_gams_directory
 from spinedb_api.spine_io.importers.reader import Reader
@@ -318,7 +319,10 @@ class ImportEditorWindow(SpecificationEditorWindowBase):
         self._import_sources.set_connector(self._connection_manager, mapping)
         self._display_input_type(reader.DISPLAY_NAME)
         extras = self._input_extras if self._input_extras is not None else {}
-        self._connection_manager.init_connection(self._input, **extras)
+        try:
+            self._connection_manager.init_connection(self._input, **extras)
+        except ReaderError as error:
+            QMessageBox.warning(self, "Failed to read source", f"Couldn't read source: {error}")
 
     def _display_input_type(self, input_type):
         """Shows connector's name on the ui.


### PR DESCRIPTION
We now show a proper error message instead of crashing.

Re spine-tools/Spine-Toolbox#2995

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
