### PR TITLE
Don't store case-normalized SQLite paths in project.json

### DIFF
--- a/spine_items/data_store/data_store.py
+++ b/spine_items/data_store/data_store.py
@@ -102,7 +102,7 @@ class DataStore(ProjectItem):
         if isinstance(url, dict):
             if url.get("dialect") == "sqlite" and (database := url.get("database")):
                 # Convert relative database path back to absolute
-                url["database"] = os.path.normcase(os.path.abspath(os.path.join(self._project.project_dir, database)))
+                url["database"] = os.path.abspath(os.path.join(self._project.project_dir, database))
             for key, value in url.items():
                 if value is not None:
                     base_url[key] = value

--- a/spine_items/utils.py
+++ b/spine_items/utils.py
@@ -84,7 +84,7 @@ def _convert_url(url):
         if dialect == "sqlite":
             database = url.get("database", "")
             if database:
-                url["database"] = os.path.normcase(os.path.abspath(database))
+                url["database"] = os.path.abspath(database)
             return URL.create("sqlite", **url)  # pylint: disable=unexpected-keyword-arg
         db_api = spinedb_api.SUPPORTED_DIALECTS.get(dialect)
         if db_api is None:

--- a/tests/data_store/test_DataStoreExecutable.py
+++ b/tests/data_store/test_DataStoreExecutable.py
@@ -18,6 +18,7 @@ from tempfile import TemporaryDirectory
 import unittest
 from unittest import mock
 from spine_engine import ExecutionDirection
+from spine_engine.utils.helpers import urls_equal
 from spine_items.data_store.executable_item import ExecutableItem
 from spine_items.utils import convert_to_sqlalchemy_url
 
@@ -83,7 +84,7 @@ class TestDataStoreExecutable(unittest.TestCase):
         self.assertEqual(len(resources), 1)
         resource = resources[0]
         self.assertEqual(resource.type_, "database")
-        self.assertEqual(resource.url, "sqlite:///" + os.path.normcase(str(db_file_path)))
+        self.assertTrue(urls_equal(resource.url, "sqlite:///" + os.path.normcase(str(db_file_path))))
         self.assertEqual(resource.label, "db_url@name")
 
     def test_output_resources_forward(self):
@@ -96,7 +97,7 @@ class TestDataStoreExecutable(unittest.TestCase):
         self.assertEqual(len(resources), 1)
         resource = resources[0]
         self.assertEqual(resource.type_, "database")
-        self.assertEqual(resource.url, "sqlite:///" + os.path.normcase(str(db_file_path)))
+        self.assertTrue(urls_equal(resource.url, "sqlite:///" + os.path.normcase(str(db_file_path))))
         self.assertEqual(resource.label, "db_url@name")
 
 

--- a/tests/data_store/test_dataStore.py
+++ b/tests/data_store/test_dataStore.py
@@ -108,7 +108,9 @@ class TestDataStoreWithToolbox(unittest.TestCase):
         # Check that DS is connected to an existing DS.sqlite file that is in data_dir
         url = self.ds_properties_ui.url_selector_widget.url_dict()
         self.assertEqual(url["dialect"], "sqlite")
-        self.assertEqual(url["database"], os.path.normcase(os.path.join(self.ds.data_dir, "temp_db.sqlite")))
+        self.assertTrue(
+            os.path.normcase(url["database"]), os.path.normcase(os.path.join(self.ds.data_dir, "temp_db.sqlite"))
+        )
         self.assertTrue(os.path.exists(url["database"]))
         expected_name = "ABC"
         expected_short_name = "abc"

--- a/tests/merger/test_MergerExecutable.py
+++ b/tests/merger/test_MergerExecutable.py
@@ -104,14 +104,14 @@ class TestMergerExecutable(unittest.TestCase):
 
     def test_write_order(self):
         db1_path = Path(self._temp_dir.name, "db1.sqlite")
-        db1_url = "sqlite:///" + os.path.normcase(str(db1_path))
+        db1_url = "sqlite:///" + str(db1_path)
         # Add some data to db1
         with DatabaseMapping(db1_url, create=True) as db1_map:
             import_functions.import_data(db1_map, entity_classes=[("fish",)])
             db1_map.commit_session("Add test data.")
         db1_map.close()
         db2_path = Path(self._temp_dir.name, "db2.sqlite")
-        db2_url = "sqlite:///" + os.path.normcase(str(db2_path))
+        db2_url = "sqlite:///" + str(db2_path)
         # Add some data to db2
         with DatabaseMapping(db2_url, create=True) as db2_map:
             import_functions.import_data(db2_map, entity_classes=[("cat",)])
@@ -119,7 +119,7 @@ class TestMergerExecutable(unittest.TestCase):
         db2_map.close()
         # Make an empty output db
         db3_path = Path(self._temp_dir.name, "db3.sqlite")
-        db3_url = "sqlite:///" + os.path.normcase(str(db3_path))
+        db3_url = "sqlite:///" + str(db3_path)
         # Make two mergers
         logger = mock.MagicMock()
         logger.__reduce__ = lambda _: (mock.MagicMock, ())


### PR DESCRIPTION
We should case-normalize paths only when doing comparisons. *NIX paths are case-sensitive, so we must store them as-is in project.json.

Fixes spine-tools/Spine-Toolbox#3038

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
