### PR TITLE
Fix Tracebacks after clearing Tool's root directory

### DIFF
--- a/spine_items/tool/tool.py
+++ b/spine_items/tool/tool.py
@@ -18,9 +18,9 @@ from spine_engine.config import TOOL_OUTPUT_DIR
 from spine_engine.project_item.project_item_resource import CmdLineArg, LabelArg, make_cmd_line_arg
 from spine_engine.utils.helpers import ExecutionDirection, resolve_julia_executable, resolve_python_interpreter
 from spine_engine.utils.serialization import deserialize_path, serialize_path
-from spinetoolbox.helpers import open_url, select_root_directory, same_path
+from spinetoolbox.helpers import open_url, same_path, select_root_directory
 from spinetoolbox.mvcmodels.file_list_models import FileListModel
-from ..commands import UpdateCmdLineArgsCommand, UpdateGroupIdCommand, UpdateRootDirCommand, UpdateResultDirCommand
+from ..commands import UpdateCmdLineArgsCommand, UpdateGroupIdCommand, UpdateResultDirCommand, UpdateRootDirCommand
 from ..db_writer_item_base import DBWriterItemBase
 from ..models import ToolCommandLineArgsModel
 from .commands import (
@@ -252,8 +252,6 @@ class Tool(DBWriterItemBase):
     def _set_root_directory(self):
         """Pushes a command to update root directory whenever the user edits the line edit."""
         root_dir = self._properties_ui.lineEdit_root_directory.text()
-        if not root_dir:
-            root_dir = None
         if self._root_directory == root_dir:
             return
         self._toolbox.undo_stack.push(UpdateRootDirCommand(self.name, root_dir, self._project))

--- a/spine_items/tool/tool_specifications.py
+++ b/spine_items/tool/tool_specifications.py
@@ -51,9 +51,7 @@ def make_specification(definition, app_settings, logger):
     if not definition["includes_main_path"]:
         path = None
     else:
-        definition["includes_main_path"] = path = definition.setdefault("includes_main_path", ".").replace(
-            "/", os.path.sep
-        )
+        definition["includes_main_path"] = path = definition["includes_main_path"].replace("/", os.path.sep)
         if not os.path.isabs(path):
             definition_file_path = definition["definition_file_path"]
             path = os.path.normpath(os.path.join(os.path.dirname(definition_file_path), path))

--- a/spine_items/tool/widgets/tool_specification_editor_window.py
+++ b/spine_items/tool/widgets/tool_specification_editor_window.py
@@ -145,9 +145,7 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
         return Ui_MainWindow()
 
     def has_root_directory(self):
-        if self.item is not None and self.item.root_dir != "":
-            return True
-        return False
+        return self.item is not None and self.item.root_dir != ""
 
     @property
     def settings_group(self):
@@ -926,13 +924,13 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
         # noinspection PyCallByClass, PyTypeChecker, PyArgumentList
         answer = QFileDialog.getOpenFileName(self, "Select existing main program file", self._start_dir(), filter)
         file_path = answer[0]
-        existing_file_paths = [
+        if not file_path:  # Cancel button clicked
+            return
+        existing_file_paths = (
             os.path.join(self.includes_main_path, i)
             for i in self.spec_dict.get("includes", [])
             if os.path.exists(os.path.join(self.includes_main_path, i))
-        ]
-        if not file_path:  # Cancel button clicked
-            return
+        )
         for i, existing_file in enumerate(existing_file_paths):
             if not existing_file:
                 continue
@@ -954,7 +952,6 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
         # noinspection PyCallByClass
         answer = QFileDialog.getSaveFileName(self, "Create new main program file", self._start_dir(), filter)
         file_path = answer[0]
-        existing_file_paths = [os.path.join(self.includes_main_path, i) for i in self.spec_dict.get("includes", [])]
         if not file_path:  # Cancel button clicked
             return
         # Remove file if it exists. getSaveFileName has asked confirmation for us.
@@ -970,7 +967,7 @@ class ToolSpecificationEditorWindow(SpecificationEditorWindowBase):
             # noinspection PyTypeChecker, PyArgumentList, PyCallByClass
             QMessageBox.information(self, "Creating file failed", msg)
             return
-        for i in existing_file_paths:
+        for i in (os.path.join(self.includes_main_path, i) for i in self.spec_dict.get("includes", [])):
             if not i:
                 continue
             if os.path.samefile(file_path, i):


### PR DESCRIPTION
This fixes Tracebacks from Tool Specification editor after Tool's root directory was cleared.

No associated issue.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
