### PR TITLE
Add unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# Copyright Spine Items contributors
+# This file is part of Spine Items.
+# Spine Items is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QApplication
+import pytest
+
+
+@pytest.fixture(scope="module")
+def application():
+    if QApplication.instance() is None:
+        QApplication()
+    application_instance = QApplication.instance()
+    yield application_instance
+    QTimer.singleShot(0, lambda: application_instance.quit())
+    application_instance.exec()

--- a/tests/mock_helpers.py
+++ b/tests/mock_helpers.py
@@ -130,3 +130,11 @@ def parent_widget():
         yield parent
     finally:
         parent.deleteLater()
+
+
+@contextmanager
+def q_object(instance):
+    try:
+        yield instance
+    finally:
+        instance.deleteLater()


### PR DESCRIPTION
Add unit tests for `ToolCommandLineArgsModel`.

Re spine-tools/Spine-Toolbox#3171

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [ ] Unit tests pass
